### PR TITLE
 _updateSelected remove `selected`  classes on other elements

### DIFF
--- a/cosmoz-data-nav.js
+++ b/cosmoz-data-nav.js
@@ -404,6 +404,10 @@
 			let classes = element.classList,
 				prev = this._selectedElement;
 
+			if (!this.animating) {
+				this._elements.forEach(el => el.classList.remove('selected'));
+			}
+
 			classes.toggle('in', this.animating);
 			classes.add('selected');
 


### PR DESCRIPTION
In _updateSelected remove `selected`  classes on other elements.
fixes #32 