### PR TITLE
Make sure we set baseProps on instance even if element.item is the same as items[index]

### DIFF
--- a/cosmoz-data-nav.js
+++ b/cosmoz-data-nav.js
@@ -214,7 +214,7 @@
 			this._elementTemplate = elementTemplate;
 			this._incompleteTemplate = incompleteTemplate;
 
-			let baseProps = {
+			const baseProps = {
 				prevDisabled: true,
 				nextDisabled: true,
 				[this.indexAs]: true
@@ -494,14 +494,18 @@
 				return;
 			}
 
-			const item = this.items[index];
+			const item = this.items[index],
+				baseProps = this._getBaseProps(index),
+				incomplete = element.__incomplete,
+				instance = element.__instance;
+
+			if (instance) {
+				Object.assign(instance, baseProps);
+			}
+
 			if (!this.isIncompleteFn(item) && element.item === item) {
 				return;
 			}
-
-			const baseProps = this._getBaseProps(index),
-				incomplete = element.__incomplete,
-				instance = element.__instance;
 
 			Object.assign(incomplete, baseProps);
 
@@ -515,7 +519,6 @@
 				return;
 			}
 
-			Object.assign(instance, baseProps);
 			instance._showHideChildren(true);
 		},
 


### PR DESCRIPTION
If item was previously available as the single item in items, prev/next will be disabled.
If items then are updated but item still is first in list, prev/next won't be updated to reflect this.