### PR TITLE
Render items only if element is attached and visible

### DIFF
--- a/cosmoz-data-nav.js
+++ b/cosmoz-data-nav.js
@@ -847,15 +847,18 @@
 				return;
 			}
 
-			this._renderRan = this._renderAbort = false;
+			if (this._isVisible) {
 
-			this._indexRenderQueue = queue
-				.sort((a, b) => a === this.selected ? -1 : b === this.selected ? 1 : 0)
-				.map(this._renderQueueProcess, this)
-				.filter(idx => idx != null);
+				this._renderRan = this._renderAbort = false;
 
-			if (this._renderAbort || this._indexRenderQueue.length === 0) {
-				return;
+				this._indexRenderQueue = queue
+					.sort((a, b) => a === this.selected ? -1 : b === this.selected ? 1 : 0)
+					.map(this._renderQueueProcess, this)
+					.filter(idx => idx != null);
+
+				if (this._renderAbort || this._indexRenderQueue.length === 0) {
+					return;
+				}
 			}
 
 			_asyncPeriod(this._renderQueue.bind(this));

--- a/cosmoz-data-nav.js
+++ b/cosmoz-data-nav.js
@@ -210,6 +210,14 @@
 			idPath: {
 				type: String,
 				value: 'id'
+			},
+
+			/**
+			 * True if element should render items even if it is not visible.
+			 */
+			hiddenRendering: {
+				type: Boolean,
+				value: false
 			}
 		},
 
@@ -847,7 +855,7 @@
 				return;
 			}
 
-			if (this._isVisible) {
+			if (this._isVisible || this.hiddenRendering) {
 
 				this._renderRan = this._renderAbort = false;
 

--- a/cosmoz-data-nav.js
+++ b/cosmoz-data-nav.js
@@ -832,6 +832,9 @@
 		},
 
 		_renderQueue() {
+			if (!this.attached) {
+				return;
+			}
 			const queue = this._indexRenderQueue;
 
 			if (!Array.isArray(queue) || queue.length < 1) {

--- a/cosmoz-data-nav.js
+++ b/cosmoz-data-nav.js
@@ -855,7 +855,7 @@
 				return;
 			}
 
-			if (this._isVisible || this.hiddenRendering) {
+			if (this.hiddenRendering || this._isVisible) {
 
 				this._renderRan = this._renderAbort = false;
 


### PR DESCRIPTION
Render items only if element is attached and visible
fixes #54 

Implementation:
In `_renderQueue` if the element is not attached we return.
In `_renderQueue` if the element is not visible but a render was request we delay another call to `_renderQueue`. 