### PR TITLE
Replace usage of event.path with event.composedPath()

### DIFF
--- a/cosmoz-data-nav.js
+++ b/cosmoz-data-nav.js
@@ -683,7 +683,7 @@
 			if (this.animating) {
 				return;
 			}
-			const path = Polymer.dom(event).path,
+			const path = event.composedPath(),
 				attr = this.selectAttribute,
 				selectEl = path.find(e => e && e.hasAttribute && e.hasAttribute(attr));
 


### PR DESCRIPTION
Replace usage of event.path with event.composedPath(), as requested in https://github.com/Neovici/cosmoz-frontend/issues/450.

This case is somewhat special since this replaces `Polymer.dom(event).path`and not `event.path`, but I compared and it appeared to be the same.