### PR TITLE
Replacing translation behavior with mixin, upgrading cosmoz-i18next component

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
 	"dependencies": {
 		"polymer": "Polymer/polymer#^2.6.1",
 		"cosmoz-bottom-bar": "Neovici/cosmoz-bottom-bar#^2.0.0",
-		"cosmoz-i18next": "Neovici/cosmoz-i18next#^2.0.0",
+		"cosmoz-i18next": "Neovici/cosmoz-i18next#^2.0.1",
 		"cosmoz-page-router": "Neovici/cosmoz-page-router#^2.0.0",
 		"iron-flex-layout": "PolymerElements/iron-flex-layout#^2.0.3",
 		"paper-icon-button": "PolymerElements/paper-icon-button#^2.2.0",

--- a/cosmoz-data-nav.html
+++ b/cosmoz-data-nav.html
@@ -8,6 +8,7 @@
 <link rel="import" href="../iron-flex-layout/iron-flex-layout-classes.html">
 
 <link rel="import" href="../cosmoz-bottom-bar/cosmoz-bottom-bar-view.html">
+<link rel="import" href="../cosmoz-i18next/cosmoz-i18next.html">
 <link rel="import" href="../cosmoz-page-router/cosmoz-page-location.html">
 
 <link rel="import" href="../paper-icon-button/paper-icon-button.html">

--- a/cosmoz-data-nav.js
+++ b/cosmoz-data-nav.js
@@ -29,10 +29,9 @@
 		} = Polymer;
 
 
-	class CosmozDataNav extends mixinBehaviors([
-		IronResizableBehavior,
-		Cosmoz.TranslatableBehavior
-	], Polymer.Element) {
+	class CosmozDataNav extends Cosmoz.Mixins.translatable(mixinBehaviors([
+		IronResizableBehavior
+	], Polymer.Element)) {
 
 		static get is() {
 			return 'cosmoz-data-nav';


### PR DESCRIPTION
Replacing translation behavior with mixin, upgrading cosmoz-i18next component.

Had to upgrade the component since `cosmoz-i18next^2.0.1` contain the mixin.

Testing, `yarn install; yarn start`.

Issue is https://github.com/Neovici/cosmoz-frontend/issues/815.