### PR TITLE
1600 - Fix: replacing disabled with hidden for previous and next buttons

### DIFF
--- a/cosmoz-data-nav.js
+++ b/cosmoz-data-nav.js
@@ -65,8 +65,8 @@ Example:
 				<template>
 						<neon-animatable class="vertical layout fit">
 								<my-view>
-										<paper-icon-button slot="actions" disabled$="[[ isFirstItem ]]" icon="chevron-left" on-click="selectPrevious"></paper-icon-button>
-										<paper-icon-button slot="actions" disabled$="[[ isLastItem ]]" icon="chevron-right" on-click="selectNext"></paper-icon-button>
+										<paper-icon-button slot="actions" hidden$="[[ isFirstItem ]]" icon="chevron-left" on-click="selectPrevious"></paper-icon-button>
+										<paper-icon-button slot="actions" hidden$="[[ isLastItem ]]" icon="chevron-right" on-click="selectNext"></paper-icon-button>
 								</my-view>
 						</neon-animatable>
 				</template>
@@ -129,8 +129,8 @@ class CosmozDataNav extends translatable(mixinBehaviors([IronResizableBehavior],
 						<h3><span>[[ _('Data is updating', t) ]]</span></h3>
 					</div>
 				</div>
-				<paper-icon-button disabled$="[[ prevDisabled ]]" icon="chevron-left" cosmoz-data-nav-select="-1"></paper-icon-button>
-				<paper-icon-button disabled$="[[ nextDisabled ]]" icon="chevron-right" cosmoz-data-nav-select="+1"></paper-icon-button>
+				<paper-icon-button hidden$="[[ prevHidden ]]" icon="chevron-left" cosmoz-data-nav-select="-1"></paper-icon-button>
+				<paper-icon-button hidden$="[[ nextHidden ]]" icon="chevron-right" cosmoz-data-nav-select="+1"></paper-icon-button>
 			</cosmoz-bottom-bar-view>
 		</template>
 `;
@@ -417,8 +417,8 @@ class CosmozDataNav extends translatable(mixinBehaviors([IronResizableBehavior],
 		this._incompleteTemplate = incompleteTemplate;
 
 		const baseProps = {
-			prevDisabled: true,
-			nextDisabled: true,
+			prevHidden: true,
+			nextHidden: true,
 			[this.indexAs]: true
 		};
 		this._elementCtor = templatize(this._elementTemplate, this, {
@@ -736,8 +736,8 @@ class CosmozDataNav extends translatable(mixinBehaviors([IronResizableBehavior],
 
 	_getBaseProps(index) {
 		return {
-			prevDisabled: index < 1,
-			nextDisabled: index + 1 >= this.items.length,
+			prevHidden: index < 1,
+			nextHidden: index + 1 >= this.items.length,
 			[this.indexAs]: Math.max(Math.min(index, this.items.length - 1), 0)
 		};
 	}

--- a/demo/helpers/cosmoz-demo-view.js
+++ b/demo/helpers/cosmoz-demo-view.js
@@ -17,9 +17,9 @@ class CosmozDemoView extends PolymerElement {
 		</style>
 		<div class="flex text">{{ item.id }}</div>
 		<div>
-			<paper-icon-button slot="actions" disabled$="[[ prevDisabled ]]" icon="chevron-left" cosmoz-data-nav-select="-1"></paper-icon-button>
+			<paper-icon-button slot="actions" hidden$="[[ prevHidden ]]" icon="chevron-left" cosmoz-data-nav-select="-1"></paper-icon-button>
 			<span>[[ index ]]</span>
-			<paper-icon-button slot="actions" disabled$="[[ nextDisabled ]]" icon="chevron-right" cosmoz-data-nav-select="+1"></paper-icon-button>
+			<paper-icon-button slot="actions" hidden$="[[ nextHidden ]]" icon="chevron-right" cosmoz-data-nav-select="+1"></paper-icon-button>
 			<paper-icon-button icon="refresh" on-tap="onReplace">Replace</paper-icon-button>
 		</div>
 `;
@@ -37,10 +37,10 @@ class CosmozDemoView extends PolymerElement {
 			index: {
 				type: Number
 			},
-			prevDisabled: {
+			prevHidden: {
 				type: Boolean
 			},
-			nextDisabled: {
+			nextHidden: {
 				type: Boolean
 			}
 		};

--- a/demo/index.html
+++ b/demo/index.html
@@ -60,7 +60,7 @@
 					<template>
 						<cosmoz-data-nav items="[[ items ]]" index-as="index" as="item" on-need-data="onNeedData" selected="{{ selected }}" selected-item="{{selItem}}" hash-param="tt">
 							<template>
-								<cosmoz-demo-view class="fit layout vertical" item="{{ item }}" index="[[index]]" data-idx$="{{ computeColorIndex(index) }}" prev-disabled="[[ prevDisabled ]]" next-disabled="[[ nextDisabled ]]"></cosmoz-demo-view>
+								<cosmoz-demo-view class="fit layout vertical" item="{{ item }}" index="[[index]]" data-idx$="{{ computeColorIndex(index) }}" prev-hidden="[[ prevHidden ]]" next-hidden="[[ nextHidden ]]"></cosmoz-demo-view>
 							</template>
 						</cosmoz-data-nav>
 						<paper-textarea value="{{ computeJSON(selected, items.*) }}">

--- a/test/helpers/cosmoz-data-nav-resizable-view.js
+++ b/test/helpers/cosmoz-data-nav-resizable-view.js
@@ -20,9 +20,9 @@ class CosmozDataNavResizableView extends mixinBehaviors([IronResizableBehavior],
 			</style>
 			<div class="flex text">{{ item.id }}</div>
 			<div>
-				<paper-icon-button slot="actions" disabled$="[[ prevDisabled ]]" icon="chevron-left" cosmoz-data-nav-select="-1"></paper-icon-button>
+				<paper-icon-button slot="actions" disabled$="[[ prevHidden ]]" icon="chevron-left" cosmoz-data-nav-select="-1"></paper-icon-button>
 				<span>[[ index ]]</span>
-				<paper-icon-button slot="actions" disabled$="[[ nextDisabled ]]" icon="chevron-right" cosmoz-data-nav-select="+1"></paper-icon-button>
+				<paper-icon-button slot="actions" disabled$="[[ nextHidden ]]" icon="chevron-right" cosmoz-data-nav-select="+1"></paper-icon-button>
 			</div>
 		`;
 	}
@@ -39,10 +39,10 @@ class CosmozDataNavResizableView extends mixinBehaviors([IronResizableBehavior],
 			index: {
 				type: Number
 			},
-			prevDisabled: {
+			prevHidden: {
 				type: Boolean
 			},
-			nextDisabled: {
+			nextHidden: {
 				type: Boolean
 			}
 		};

--- a/test/helpers/cosmoz-data-nav-test-view.js
+++ b/test/helpers/cosmoz-data-nav-test-view.js
@@ -17,9 +17,9 @@ class CosmozDataNavTestView extends PolymerElement {
 			</style>
 			<div class="flex text">{{ item.id }}</div>
 			<div>
-				<paper-icon-button slot="actions" disabled$="[[ prevDisabled ]]" icon="chevron-left" cosmoz-data-nav-select="-1"></paper-icon-button>
+				<paper-icon-button slot="actions" disabled$="[[ prevHidden ]]" icon="chevron-left" cosmoz-data-nav-select="-1"></paper-icon-button>
 				<span>[[ index ]]</span>
-				<paper-icon-button slot="actions" disabled$="[[ nextDisabled ]]" icon="chevron-right" cosmoz-data-nav-select="+1"></paper-icon-button>
+				<paper-icon-button slot="actions" disabled$="[[ nextHidden ]]" icon="chevron-right" cosmoz-data-nav-select="+1"></paper-icon-button>
 			</div>
 		`;
 	}
@@ -36,10 +36,10 @@ class CosmozDataNavTestView extends PolymerElement {
 			index: {
 				type: Number
 			},
-			prevDisabled: {
+			prevHidden: {
 				type: Boolean
 			},
-			nextDisabled: {
+			nextHidden: {
 				type: Boolean
 			}
 		};


### PR DESCRIPTION
Fix: replacing disabled with hidden for previous and next buttons.

Testing, check that the browse buttons are displayed and hidden when expected to.