### PR TITLE
feat: react to items splices

### DIFF
--- a/cosmoz-data-nav.js
+++ b/cosmoz-data-nav.js
@@ -340,6 +340,21 @@ class CosmozDataNav extends translatable(mixinBehaviors([IronResizableBehavior],
 		};
 	}
 
+	static get observers() {
+		return [
+			'_onItemsSplices(items.splices)'
+		];
+	}
+
+	_onItemsSplices(change) {
+		if (!change) {
+			return;
+		}
+
+		// TODO: react more intelligently
+		this._itemsChanged(change.indexSplices[0].object);
+	}
+
 	constructor() {
 		super();
 		this._previouslySelectedItem = null;

--- a/test/index.html
+++ b/test/index.html
@@ -9,10 +9,10 @@
 <body>
 	<script>
 		WCT.loadSuites([
-			'basic.html',
-			'resizable.html',
-			'spec.html',
-			'bugs.html'
+			// 'basic.html',
+			// 'resizable.html',
+			'spec.html'
+			// 'bugs.html'
 		]);
 	</script>
 </body></html>

--- a/test/spec.html
+++ b/test/spec.html
@@ -194,6 +194,23 @@
 							expect(selectedSlide(nav).textContent).to.equal('id: a,index: 0freshdata');
 						}).throws('expected \'id: a,index: 0somedata\' to equal \'id: a,index: 0freshdata\'');
 					});
+
+					it.only('reacts to splices', () => {
+						nav.items = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
+						flushRenderQueue(nav);
+
+						expect(selectedSlide(nav).textContent).to.equal('id: a,index: 0');
+
+						nav.push('items', [{id: 'd'}]);
+						flushRenderQueue(nav);
+
+						expect(selectedSlide(nav).textContent).to.equal('id: a,index: 0');
+
+						nav.splice('items', 0, 3);
+						flushRenderQueue(nav);
+
+						expect(selectedSlide(nav).textContent).to.equal('id: d,index: 0');
+					});
 				});
 
 				describe('maintainSelection', () => {


### PR DESCRIPTION
https://neovici.slack.com/archives/DGX65MV34/p1573216568033400

`cosmoz-omnitable` uses `cosmoz-grouped-list`, which updates the `selectedItems` array using array splices (`this.push`, `this.splice`). The spliced updates are not observed by `cosmoz-data-nav`, which only observes reference changes. This causes the `data-nav` to not react to `omnitable` selections. 

WIP, because I still need to add some tests.