### PR TITLE
feat: extend error message details

### DIFF
--- a/cosmoz-data-nav.js
+++ b/cosmoz-data-nav.js
@@ -506,11 +506,11 @@ class CosmozDataNav extends translatable(mixinBehaviors([IronResizableBehavior],
 
 		if (matches.length === 0) {
 			// eslint-disable-next-line no-console
-			console.warn('trying to replace an item that is not in the list', id, item);
+			console.warn('List item replacement failed, no matching idPath', this.idPath, 'with id', id, 'in the item list', items, 'to replace with item', item);
 			return;
 		} else if (matches.length > 1) {
 			// eslint-disable-next-line no-console
-			console.warn('found multiple items with same id');
+			console.log('Multiple replaceable items matches idPath', this.idPath, 'with id', id, 'in the item list', items, 'to replace with item', item);
 		}
 
 		this._cache[id] = Object.assign({}, item);

--- a/cosmoz-data-nav.js
+++ b/cosmoz-data-nav.js
@@ -510,7 +510,7 @@ class CosmozDataNav extends translatable(mixinBehaviors([IronResizableBehavior],
 			return;
 		} else if (matches.length > 1) {
 			// eslint-disable-next-line no-console
-			console.log('Multiple replaceable items matches idPath', this.idPath, 'with id', id, 'in the item list', items, 'to replace with item', item);
+			console.warn('Multiple replaceable items matches idPath', this.idPath, 'with id', id, 'in the item list', items, 'to replace with item', item);
 		}
 
 		this._cache[id] = Object.assign({}, item);

--- a/test/basic.html
+++ b/test/basic.html
@@ -175,7 +175,13 @@
 						data = { id: 0 },
 						cache = nav._cache;
 					nav.setItemById('0', data);
-					assert.isTrue(warnSpy.calledWithMatch(sinon.match(/Multiple replaceable items matches idPath id with id 0 in the item list/iu)), true);
+					sinon.assert.calledWith(warnSpy,
+						'Multiple replaceable items matches idPath',
+						'id',
+						'with id',
+						'0',
+						'in the item list', nav.items,
+						'to replace with item', {id: 0});
 					assert.equal(cache['0'].id, data.id);
 					assert.equal(nav.items[0].id, data.id);
 					assert.equal(nav.items[1].id, data.id);
@@ -271,7 +277,15 @@
 					const warnSpy = sinon.spy(console, 'warn'),
 						data = { id: 23 };
 					nav.setItemById('23', data);
-					assert.isTrue(warnSpy.calledWithMatch(sinon.match(/List item replacement failed, no matching idPath id with id 23 in the item list/iu)), true);
+					sinon.assert.calledWith(warnSpy,
+						'List item replacement failed, no matching idPath',
+						'id',
+						'with id',
+						'23',
+						'in the item list',
+						nav.items,
+						'to replace with item',
+						data);
 					warnSpy.restore();
 				});
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -175,7 +175,7 @@
 						data = { id: 0 },
 						cache = nav._cache;
 					nav.setItemById('0', data);
-					assert.isTrue(warnSpy.calledWithMatch('/Multiple replaceable items matches idPath id with id 0 in the item list/'), true);
+					assert.isTrue(warnSpy.calledWithMatch(sinon.match.regexp('/Multiple replaceable items matches idPath id with id 0 in the item list/')), true);
 					assert.equal(cache['0'].id, data.id);
 					assert.equal(nav.items[0].id, data.id);
 					assert.equal(nav.items[1].id, data.id);
@@ -271,7 +271,7 @@
 					const warnSpy = sinon.spy(console, 'warn'),
 						data = { id: 23 };
 					nav.setItemById('23', data);
-					assert.isTrue(warnSpy.calledWithMatch('/List item replacement failed, no matching idPath id with id 23 in the item list/'), true);
+					assert.isTrue(warnSpy.calledWithMatch(sinon.match.regexp('/List item replacement failed, no matching idPath id with id 23 in the item list/')), true);
 					warnSpy.restore();
 				});
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -175,7 +175,7 @@
 						data = { id: 0 },
 						cache = nav._cache;
 					nav.setItemById('0', data);
-					assert.isTrue(warnSpy.calledWithMatch(sinon.match('/Multiple replaceable items matches idPath id with id 0 in the item list/')), true);
+					assert.isTrue(warnSpy.calledWithMatch(sinon.match('/Multiple replaceable items matches idPath id with id 0 in the item list/iu')), true);
 					assert.equal(cache['0'].id, data.id);
 					assert.equal(nav.items[0].id, data.id);
 					assert.equal(nav.items[1].id, data.id);
@@ -271,7 +271,7 @@
 					const warnSpy = sinon.spy(console, 'warn'),
 						data = { id: 23 };
 					nav.setItemById('23', data);
-					assert.isTrue(warnSpy.calledWithMatch(sinon.match('/List item replacement failed, no matching idPath id with id 23 in the item list/')), true);
+					assert.isTrue(warnSpy.calledWithMatch(sinon.match('/List item replacement failed, no matching idPath id with id 23 in the item list/iu')), true);
 					warnSpy.restore();
 				});
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -175,7 +175,7 @@
 						data = { id: 0 },
 						cache = nav._cache;
 					nav.setItemById('0', data);
-					assert.isTrue(warnSpy.calledWithExactly('found multiple items with same id'), true);
+					assert.isTrue(warnSpy.calledWithMatch('/Multiple replaceable items matches idPath id with id 0 in the item list/'), true);
 					assert.equal(cache['0'].id, data.id);
 					assert.equal(nav.items[0].id, data.id);
 					assert.equal(nav.items[1].id, data.id);
@@ -271,7 +271,7 @@
 					const warnSpy = sinon.spy(console, 'warn'),
 						data = { id: 23 };
 					nav.setItemById('23', data);
-					assert.isTrue(warnSpy.calledWithExactly('trying to replace an item that is not in the list', '23', data), true);
+					assert.isTrue(warnSpy.calledWithMatch('/List item replacement failed, no matching idPath id with id 23 in the item list/'), true);
 					warnSpy.restore();
 				});
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -175,7 +175,7 @@
 						data = { id: 0 },
 						cache = nav._cache;
 					nav.setItemById('0', data);
-					assert.isTrue(warnSpy.calledWithMatch(sinon.match('/Multiple replaceable items matches idPath id with id 0 in the item list/iu')), true);
+					assert.isTrue(warnSpy.calledWithMatch(sinon.match(/Multiple replaceable items matches idPath id with id 0 in the item list/iu)), true);
 					assert.equal(cache['0'].id, data.id);
 					assert.equal(nav.items[0].id, data.id);
 					assert.equal(nav.items[1].id, data.id);
@@ -271,7 +271,7 @@
 					const warnSpy = sinon.spy(console, 'warn'),
 						data = { id: 23 };
 					nav.setItemById('23', data);
-					assert.isTrue(warnSpy.calledWithMatch(sinon.match('/List item replacement failed, no matching idPath id with id 23 in the item list/iu')), true);
+					assert.isTrue(warnSpy.calledWithMatch(sinon.match(/List item replacement failed, no matching idPath id with id 23 in the item list/iu)), true);
 					warnSpy.restore();
 				});
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -175,7 +175,7 @@
 						data = { id: 0 },
 						cache = nav._cache;
 					nav.setItemById('0', data);
-					assert.isTrue(warnSpy.calledWithMatch(sinon.match.regexp('/Multiple replaceable items matches idPath id with id 0 in the item list/')), true);
+					assert.isTrue(warnSpy.calledWithMatch(sinon.match('/Multiple replaceable items matches idPath id with id 0 in the item list/')), true);
 					assert.equal(cache['0'].id, data.id);
 					assert.equal(nav.items[0].id, data.id);
 					assert.equal(nav.items[1].id, data.id);
@@ -271,7 +271,7 @@
 					const warnSpy = sinon.spy(console, 'warn'),
 						data = { id: 23 };
 					nav.setItemById('23', data);
-					assert.isTrue(warnSpy.calledWithMatch(sinon.match.regexp('/List item replacement failed, no matching idPath id with id 23 in the item list/')), true);
+					assert.isTrue(warnSpy.calledWithMatch(sinon.match('/List item replacement failed, no matching idPath id with id 23 in the item list/')), true);
 					warnSpy.restore();
 				});
 


### PR DESCRIPTION
Extend error message details so they tell more about what the error is about.

* Tell the `idPath` that is being used, a common cause of error is a misconfigured `idPath` (`id-path`).

* Tell the list data, a cause of error is an empty list or one that does not have the expected data.

* Reformat the `id` and `item` data presentation so it explains what these are.

No issue.
