### PR TITLE
fix(selected-instance): is always the incomplete template

### DIFF
--- a/cosmoz-data-nav.js
+++ b/cosmoz-data-nav.js
@@ -760,7 +760,8 @@ class CosmozDataNav extends translatable(mixinBehaviors([IronResizableBehavior],
 		if (selectedElement == null) {
 			return;
 		}
-		return selectedElement.children[0];
+		// return reference to the rendered template instance or the incomplete template if missing
+		return selectedElement.children[1] || selectedElement.children[0];
 	}
 
 	_getItem(index, items = this.items) {


### PR DESCRIPTION
BUG: selectedInstance used to return a reference to the rendered template, but now it returns only the incomplete template

Affects RM:23989

Broken in https://github.com/Neovici/cosmoz-data-nav/commit/c2908eb4d6f726d4ae1eb3c3dc45865964b917a3