### PR TITLE
Update selectedInstance after rendering

### DIFF
--- a/cosmoz-data-nav.js
+++ b/cosmoz-data-nav.js
@@ -1096,6 +1096,7 @@ class CosmozDataNav extends translatable(mixinBehaviors([IronResizableBehavior],
 			// resize is a expensive operation
 			this._renderRan = this._notifyElementResize();
 		}
+		this._setSelectedInstance(this._getInstance(element));
 	}
 
 	_onCachePurge(e) {

--- a/test/bugs.test.js
+++ b/test/bugs.test.js
@@ -136,15 +136,8 @@ suite('bugs', () => {
 		nav.setItemById('0', { id: '0' });
 		nav.setItemById('1', { id: '1' });
 		flushRenderQueue(nav);
-		let bug = false;
-		try {
-			assert.isOk(nav.selectedInstance);
-		} catch (e) {
-			assert.equal(e.message, 'expected undefined to be truthy');
-			bug = true;
-		}
+		assert.isOk(nav.selectedInstance);
 		nav.selected = 1;
 		assert.isOk(nav.selectedInstance);
-		assert.isTrue(bug, 'bug fixed?');
 	});
 });

--- a/test/spec.test.js
+++ b/test/spec.test.js
@@ -346,11 +346,8 @@ suite('properties', () => {
 	});
 
 	suite('selectedInstance', () => {
-		test('exposes the instance of the selected item');
-		test('does not work properly [KNOWN BUG]', () => {
-			expect(() => {
-				expect(nav.selectedInstance).to.exist;
-			}).throws('expected undefined to exist');
+		test('exposes the instance of the selected item', () => {
+			expect(nav.selectedInstance).to.exist;
 		});
 	});
 


### PR DESCRIPTION
selectedInstance gets set to incomplete when the template
instance is not available. Sync after rendering to restore it
to the item instance.