### PR TITLE
fix: make sure selected instance isn't updated for preloads

### DIFF
--- a/cosmoz-data-nav.js
+++ b/cosmoz-data-nav.js
@@ -1095,8 +1095,8 @@ class CosmozDataNav extends translatable(mixinBehaviors([IronResizableBehavior],
 			element.__instance._showHideChildren(false);
 			// resize is a expensive operation
 			this._renderRan = this._notifyElementResize();
+			this._setSelectedInstance(this._getInstance(element));
 		}
-		this._setSelectedInstance(this._getInstance(element));
 	}
 
 	_onCachePurge(e) {


### PR DESCRIPTION
Previous fix was _almost_ right!

Signed-off-by: Patrik Kullman <patrik.kullman@neovici.se>