### PR TITLE
fix: drop iron-flex-layout

### DIFF
--- a/cosmoz-data-nav.js
+++ b/cosmoz-data-nav.js
@@ -1,8 +1,6 @@
 /* eslint-disable max-lines */
 import '@webcomponents/shadycss/entrypoints/apply-shim';
 
-import '@polymer/iron-flex-layout/iron-flex-layout';
-import '@polymer/iron-flex-layout/iron-flex-layout-classes';
 import '@polymer/paper-icon-button';
 import '@polymer/paper-spinner/paper-spinner-lite';
 
@@ -82,7 +80,7 @@ Example:
 class CosmozDataNav extends hauntedPolymer('__cache', useCache)(translatable(mixinBehaviors([IronResizableBehavior], PolymerElement))) {
 	static get template() { // eslint-disable-line max-lines-per-function
 		return html`
-			<style include="iron-flex iron-positioning">
+			<style>
 				:host {
 					position: relative;
 				}
@@ -93,10 +91,18 @@ class CosmozDataNav extends hauntedPolymer('__cache', useCache)(translatable(mix
 
 				#items,
 				#items > ::slotted(.animatable){
-					@apply --layout-fit;
 					transform: translateX(0px);
 				}
 
+				.fit,
+				#items,
+				#items > ::slotted(.animatable) {
+					position: absolute;
+					top: 0;
+					right: 0;
+					bottom: 0;
+					left: 0;
+				}
 				:host([animating]) #items > ::slotted(.animatable){
 					transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1) 0s;
 					backface-visibility: hidden;
@@ -127,7 +133,7 @@ class CosmozDataNav extends hauntedPolymer('__cache', useCache)(translatable(mix
 			</div>
 			<template id="incompleteTemplate">
 				<cosmoz-bottom-bar-view active incomplete class="fit">
-					<div slot="scroller-content" class="flex layout horizontal center-justified center">
+					<div slot="scroller-content">
 						<paper-spinner-lite active></paper-spinner-lite>
 						<div style="margin-left: 10px">
 							<h3><span>[[ _('Data is updating', t) ]]</span></h3>

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -1,0 +1,79 @@
+import {
+	component, html, useMemo, useState, useEffect
+} from 'haunted';
+import '@polymer/paper-input/paper-textarea.js';
+import './helpers/cosmoz-demo-view.js';
+import '../cosmoz-data-nav.js';
+
+const asyncs = {},
+	// eslint-disable-next-line max-lines-per-function
+	DataNavDemo = function () {
+
+		const items = useMemo(() => Array(20).fill('').map((e, i) => i.toString()), []),
+			[selected, setSelected] = useState(),
+			[selItem, setSelItem] = useState(),
+			[instance, setInstance] = useState(),
+			onNeedData = event => {
+				const id = event.detail.id,
+					dataNav = event.target;
+				if (asyncs[id]) {
+					clearTimeout(asyncs[id]);
+					asyncs[id] = null;
+				}
+				// eslint-disable-next-line no-console
+				console.log('on need data', event.target, event.srcElement);
+				asyncs[id] = setTimeout(() => dataNav.setItemById(id, { id }), 500);
+			},
+			computeJSON = index => JSON.stringify(items[index]);
+
+		useEffect(() => {
+			if (instance?.dataset == null) {
+				return;
+			}
+			instance.dataset.idx = selected % 3;
+		}, [instance]);
+
+		return html`
+            <style>
+                #container {
+                    max-width: 800px;
+                }
+                cosmoz-data-nav {
+                    display: block;
+                    height: 400px;
+                    position: relative;
+                }
+                cosmoz-demo-view {
+                    display: flex;
+                    flex-direction: column;
+                }
+                [data-idx="0"] {
+                    background-color: blue;
+                }
+                [data-idx="1"] {
+                    background-color: red;
+                }
+                [data-idx="2"] {
+                    background-color: orange;
+                }
+            </style>
+            <cosmoz-data-nav hash-param="tt"
+                    .items="${ items }"
+                    @need-data="${ onNeedData }"
+                    @selected-changed="${ e => setSelected(e?.detail?.value) }"
+                    @selected-item-changed="${ e => setSelItem(e?.detail?.value) }"
+                    @selected-instance-changed="${ e => setInstance(e?.detail?.value) }"
+            >
+                <template>
+                    <cosmoz-demo-view
+                        item="{{ item }}" index="[[ index ]]"
+                        prev-disabled="[[ prevDisabled ]]" next-disabled="[[ nextDisabled ]]">
+                    </cosmoz-demo-view>
+                </template>
+            </cosmoz-data-nav>
+            <paper-textarea value="${ computeJSON(selected) }"></paper-textarea>
+            <div>Selected: ${ JSON.stringify(selItem) }</div>
+        `;
+	};
+
+customElements.define('data-nav-demo', component(DataNavDemo));

--- a/demo/helpers/cosmoz-demo-view.js
+++ b/demo/helpers/cosmoz-demo-view.js
@@ -1,6 +1,4 @@
 import '@polymer/paper-icon-button/paper-icon-button';
-import '@polymer/iron-flex-layout/iron-flex-layout';
-import '@polymer/iron-flex-layout/iron-flex-layout-classes';
 import '@polymer/iron-icons/iron-icons.js';
 
 import { PolymerElement } from '@polymer/polymer/polymer-element';
@@ -15,12 +13,14 @@ class CosmozDemoView extends dataNavUserMixin(PolymerElement) {
 		return html`
 			<style>
 				.text {
+					flex: 1;
+					flex-basis: 0.000000001px;
 					font-size: 300px;
 					line-height: 360px;
 					text-align: center;
 				}
 			</style>
-			<div class="flex text">[[ item.id ]]</div>
+			<div class="text">[[ item.id ]]</div>
 			<div>
 				<paper-icon-button slot="actions" disabled$="[[ prevDisabled ]]" icon="chevron-left" cosmoz-data-nav-select="-1"></paper-icon-button>
 				<span>[[ index ]]</span>

--- a/demo/index.html
+++ b/demo/index.html
@@ -5,92 +5,13 @@
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 	<title>cosmoz-data-nav demo</title>
+	<script type="module" src="./demo.js"></script>
 </head>
 
 <body unresolved>
 	<div id="container" class="vertical-section-container centered">
 		<h3>Basic <code>cosmoz-data-nav</code>.</h3>
-		<dom-bind id="basic">
-			<template>
-				<cosmoz-data-nav items="[[ items ]]" index-as="index" as="item"
-						on-need-data="onNeedData" selected="{{ selected }}" selected-item="{{ selItem }}" hash-param="tt">
-					<template>
-						<cosmoz-demo-view class="fit layout vertical"
-							item="{{ item }}" index="[[ index ]]" data-idx$="[[ computeColorIndex(index) ]]"
-							prev-disabled="[[ prevDisabled ]]" next-disabled="[[ nextDisabled ]]">
-						</cosmoz-demo-view>
-					</template>
-				</cosmoz-data-nav>
-				<paper-textarea value="[[ computeJSON(selected, items.*) ]]">
-				</paper-textarea>
-					<div>Selected: [[ toJSON(selItem) ]]</div>
-			</template>
-		</dom-bind>
+		<data-nav-demo></data-nav-demo>
 	</div>
-
-	<script type="module">
-		import '@polymer/polymer/lib/elements/custom-style.js';
-		import '@polymer/polymer/lib/elements/dom-bind.js';
-		import '@polymer/paper-input/paper-textarea.js';
-		import './helpers/cosmoz-demo-view.js';
-		import '../cosmoz-data-nav.js';
-
-		const container = document.createElement('template');
-		container.innerHTML = `
-			<custom-style>
-				<style include="iron-flex">
-					#container {
-						max-width: 800px;
-					}
-					cosmoz-data-nav {
-						display: block;
-						height: 400px;
-						position: relative;
-					}
-					[data-idx="0"]{
-						background-color: blue;
-					}
-					[data-idx="1"]{
-						background-color: red;
-					}
-					[data-idx="2"]{
-						background-color: orange;
-					}
-				</style>
-			</custom-style>
-		`;
-		document.body.appendChild(container.content);
-
-		import { Base } from '@polymer/polymer/polymer-legacy';
-
-		let basic = document.getElementById('basic');
-		const items = Array(20).fill('').map((e, i) => i.toString()),
-			asyncs = {};
-
-		basic = !basic.set ? basic.firstElementChild : basic;
-
-		Object.assign(basic, {
-			computeColorIndex: index => index % 3,
-			onNeedData: (event, detail) => {
-				const id = detail.id;
-				if (asyncs[id]) {
-					Base.cancelAsync(asyncs[id]);
-					asyncs[id] = null;
-				}
-				// eslint-disable-next-line no-console
-				console.log('on need data');
-				asyncs[id] = Base.async(() => {
-					event.target.setItemById(detail.id, { id: detail.id });
-				}, 500);
-				return { id: detail.id };
-			},
-			computeJSON(index) {
-				return JSON.stringify(this.items[index]);
-			},
-			toJSON: item => JSON.stringify(item)
-		});
-
-		basic.set('items', items);
-	</script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -206,6 +206,64 @@
 				"@babel/helper-get-function-arity": "^7.10.1",
 				"@babel/template": "^7.10.1",
 				"@babel/types": "^7.10.1"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.10.3",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.3.tgz",
+					"integrity": "sha512-fDx9eNW0qz0WkUeqL6tXEXzVlPh6Y5aCDEZesl0xBGA8ndRukX91Uk44ZqnkECp01NAZUdCAl+aiQNGi0k88Eg==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.10.3"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.10.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.3.tgz",
+					"integrity": "sha512-bU8JvtlYpJSBPuj1VUmKpFGaDZuLxASky3LhaKj3bmpSTY6VWooSM8msk+Z0CZoErFye2tlABF6yDkT3FOPAXw==",
+					"dev": true
+				},
+				"@babel/highlight": {
+					"version": "7.10.3",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.3.tgz",
+					"integrity": "sha512-Ih9B/u7AtgEnySE2L2F0Xm0GaM729XqqLfHkalTsbjXGyqmf/6M0Cu0WpvqueUlW+xk88BHw9Nkpj49naU+vWw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.3",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.10.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.3.tgz",
+					"integrity": "sha512-oJtNJCMFdIMwXGmx+KxuaD7i3b8uS7TTFYW/FNG2BT8m+fmGHoiPYoH0Pe3gya07WuFmM5FCDIr1x0irkD/hyA==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.10.3",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.3.tgz",
+					"integrity": "sha512-5BjI4gdtD+9fHZUsaxPHPNpwa+xRkDO7c7JbhYn2afvrkDu5SfAAbi9AIMXw2xEhO/BR35TqiW97IqNvCo/GqA==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.10.3",
+						"@babel/parser": "^7.10.3",
+						"@babel/types": "^7.10.3"
+					},
+					"dependencies": {
+						"@babel/types": {
+							"version": "7.10.3",
+							"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.3.tgz",
+							"integrity": "sha512-nZxaJhBXBQ8HVoIcGsf9qWep3Oh3jCENK54V4mRF7qaJabVsAYdbTtmSD8WmAp1R6ytPiu5apMwSXyxB1WlaBA==",
+							"dev": true,
+							"requires": {
+								"@babel/helper-validator-identifier": "^7.10.3",
+								"lodash": "^4.17.13",
+								"to-fast-properties": "^2.0.0"
+							}
+						}
+					}
+				}
 			}
 		},
 		"@babel/helper-get-function-arity": {
@@ -306,6 +364,153 @@
 				"@babel/helper-optimise-call-expression": "^7.10.1",
 				"@babel/traverse": "^7.10.1",
 				"@babel/types": "^7.10.1"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.10.3",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.3.tgz",
+					"integrity": "sha512-fDx9eNW0qz0WkUeqL6tXEXzVlPh6Y5aCDEZesl0xBGA8ndRukX91Uk44ZqnkECp01NAZUdCAl+aiQNGi0k88Eg==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.10.3"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.10.3",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.3.tgz",
+					"integrity": "sha512-drt8MUHbEqRzNR0xnF8nMehbY11b1SDkRw03PSNH/3Rb2Z35oxkddVSi3rcaak0YJQ86PCuE7Qx1jSFhbLNBMA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.10.3",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
+					},
+					"dependencies": {
+						"@babel/types": {
+							"version": "7.10.3",
+							"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.3.tgz",
+							"integrity": "sha512-nZxaJhBXBQ8HVoIcGsf9qWep3Oh3jCENK54V4mRF7qaJabVsAYdbTtmSD8WmAp1R6ytPiu5apMwSXyxB1WlaBA==",
+							"dev": true,
+							"requires": {
+								"@babel/helper-validator-identifier": "^7.10.3",
+								"lodash": "^4.17.13",
+								"to-fast-properties": "^2.0.0"
+							}
+						}
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.10.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.3.tgz",
+					"integrity": "sha512-FvSj2aiOd8zbeqijjgqdMDSyxsGHaMt5Tr0XjQsGKHD3/1FP3wksjnLAWzxw7lvXiej8W1Jt47SKTZ6upQNiRw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.10.3",
+						"@babel/template": "^7.10.3",
+						"@babel/types": "^7.10.3"
+					},
+					"dependencies": {
+						"@babel/template": {
+							"version": "7.10.3",
+							"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.3.tgz",
+							"integrity": "sha512-5BjI4gdtD+9fHZUsaxPHPNpwa+xRkDO7c7JbhYn2afvrkDu5SfAAbi9AIMXw2xEhO/BR35TqiW97IqNvCo/GqA==",
+							"dev": true,
+							"requires": {
+								"@babel/code-frame": "^7.10.3",
+								"@babel/parser": "^7.10.3",
+								"@babel/types": "^7.10.3"
+							}
+						},
+						"@babel/types": {
+							"version": "7.10.3",
+							"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.3.tgz",
+							"integrity": "sha512-nZxaJhBXBQ8HVoIcGsf9qWep3Oh3jCENK54V4mRF7qaJabVsAYdbTtmSD8WmAp1R6ytPiu5apMwSXyxB1WlaBA==",
+							"dev": true,
+							"requires": {
+								"@babel/helper-validator-identifier": "^7.10.3",
+								"lodash": "^4.17.13",
+								"to-fast-properties": "^2.0.0"
+							}
+						}
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.10.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.3.tgz",
+					"integrity": "sha512-iUD/gFsR+M6uiy69JA6fzM5seno8oE85IYZdbVVEuQaZlEzMO2MXblh+KSPJgsZAUx0EEbWXU0yJaW7C9CdAVg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.10.3"
+					},
+					"dependencies": {
+						"@babel/types": {
+							"version": "7.10.3",
+							"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.3.tgz",
+							"integrity": "sha512-nZxaJhBXBQ8HVoIcGsf9qWep3Oh3jCENK54V4mRF7qaJabVsAYdbTtmSD8WmAp1R6ytPiu5apMwSXyxB1WlaBA==",
+							"dev": true,
+							"requires": {
+								"@babel/helper-validator-identifier": "^7.10.3",
+								"lodash": "^4.17.13",
+								"to-fast-properties": "^2.0.0"
+							}
+						}
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.10.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.3.tgz",
+					"integrity": "sha512-bU8JvtlYpJSBPuj1VUmKpFGaDZuLxASky3LhaKj3bmpSTY6VWooSM8msk+Z0CZoErFye2tlABF6yDkT3FOPAXw==",
+					"dev": true
+				},
+				"@babel/highlight": {
+					"version": "7.10.3",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.3.tgz",
+					"integrity": "sha512-Ih9B/u7AtgEnySE2L2F0Xm0GaM729XqqLfHkalTsbjXGyqmf/6M0Cu0WpvqueUlW+xk88BHw9Nkpj49naU+vWw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.3",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.10.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.3.tgz",
+					"integrity": "sha512-oJtNJCMFdIMwXGmx+KxuaD7i3b8uS7TTFYW/FNG2BT8m+fmGHoiPYoH0Pe3gya07WuFmM5FCDIr1x0irkD/hyA==",
+					"dev": true
+				},
+				"@babel/template": {},
+				"@babel/traverse": {
+					"version": "7.10.3",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.3.tgz",
+					"integrity": "sha512-qO6623eBFhuPm0TmmrUFMT1FulCmsSeJuVGhiLodk2raUDFhhTECLd9E9jC4LBIWziqt4wgF6KuXE4d+Jz9yug==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.10.3",
+						"@babel/generator": "^7.10.3",
+						"@babel/helper-function-name": "^7.10.3",
+						"@babel/helper-split-export-declaration": "^7.10.1",
+						"@babel/parser": "^7.10.3",
+						"@babel/types": "^7.10.3",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					},
+					"dependencies": {
+						"@babel/types": {
+							"version": "7.10.3",
+							"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.3.tgz",
+							"integrity": "sha512-nZxaJhBXBQ8HVoIcGsf9qWep3Oh3jCENK54V4mRF7qaJabVsAYdbTtmSD8WmAp1R6ytPiu5apMwSXyxB1WlaBA==",
+							"dev": true,
+							"requires": {
+								"@babel/helper-validator-identifier": "^7.10.3",
+								"lodash": "^4.17.13",
+								"to-fast-properties": "^2.0.0"
+							}
+						}
+					}
+				}
 			}
 		},
 		"@babel/helper-simple-access": {
@@ -1104,157 +1309,358 @@
 			}
 		},
 		"@commitlint/cli": {
-			"version": "8.3.5",
-			"resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-8.3.5.tgz",
-			"integrity": "sha512-6+L0vbw55UEdht71pgWOE55SRgb+8OHcEwGDB234VlIBFGK9P2QOBU7MHiYJ5cjdjCQ0rReNrGjOHmJ99jwf0w==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-9.0.1.tgz",
+			"integrity": "sha512-BVOc/BY0FMmKTTH5oUVE0ukhPWDFf364FiYKk3GlXLOGTZPTXQ/9ncB2eMOaCF0PdcEVY4VoMjyoRSgcVapCMg==",
 			"dev": true,
 			"requires": {
-				"@commitlint/format": "^8.3.4",
-				"@commitlint/lint": "^8.3.5",
-				"@commitlint/load": "^8.3.5",
-				"@commitlint/read": "^8.3.4",
-				"babel-polyfill": "6.26.0",
-				"chalk": "2.4.2",
+				"@babel/runtime": "^7.9.6",
+				"@commitlint/format": "^9.0.1",
+				"@commitlint/lint": "^9.0.1",
+				"@commitlint/load": "^9.0.1",
+				"@commitlint/read": "^9.0.1",
+				"chalk": "3.0.0",
+				"core-js": "^3.6.1",
 				"get-stdin": "7.0.0",
-				"lodash": "4.17.15",
+				"lodash": "^4.17.15",
 				"meow": "5.0.0",
+				"regenerator-runtime": "0.13.3",
 				"resolve-from": "5.0.0",
 				"resolve-global": "1.0.0"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.10.3",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.3.tgz",
+					"integrity": "sha512-RzGO0RLSdokm9Ipe/YD+7ww8X2Ro79qiXZF3HU9ljrM+qnJmH1Vqth+hbiQZy761LnMJTMitHDuKVYTk3k4dLw==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					},
+					"dependencies": {
+						"regenerator-runtime": {
+							"version": "0.13.5",
+							"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+							"integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+							"dev": true
+						}
+					}
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"regenerator-runtime": {
+					"version": "0.13.3",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+					"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"@commitlint/config-conventional": {
-			"version": "8.3.4",
-			"resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-8.3.4.tgz",
-			"integrity": "sha512-w0Yc5+aVAjZgjYqx29igBOnVCj8O22gy3Vo6Fyp7PwoS7+AYS1x3sN7IBq6i7Ae15Mv5P+rEx1pkxXo5zOMe4g==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-9.0.1.tgz",
+			"integrity": "sha512-5rGu8aT4nRhWKrd5SpXqKJKLM07wXi4X5KVD9EEAuucAh2iZgfJJK9HKZNKGEKLKBQSWlnXE6UvkeEjJgi6TPQ==",
 			"dev": true,
 			"requires": {
-				"conventional-changelog-conventionalcommits": "4.2.1"
+				"conventional-changelog-conventionalcommits": "4.2.3"
 			}
 		},
 		"@commitlint/ensure": {
-			"version": "8.3.4",
-			"resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-8.3.4.tgz",
-			"integrity": "sha512-8NW77VxviLhD16O3EUd02lApMFnrHexq10YS4F4NftNoErKbKaJ0YYedktk2boKrtNRf/gQHY/Qf65edPx4ipw==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-9.0.1.tgz",
+			"integrity": "sha512-z8SEkfbn0lMnAtt7Hp3A8hE3CRCDsg+Eu3Xj1UJakOyCPJgHE1/vEyM2DO2dxTXVKuttiHeLDnUSHCxklm78Ng==",
 			"dev": true,
 			"requires": {
-				"lodash": "4.17.15"
+				"@commitlint/types": "^9.0.1",
+				"lodash": "^4.17.15"
 			}
 		},
 		"@commitlint/execute-rule": {
-			"version": "8.3.4",
-			"resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-8.3.4.tgz",
-			"integrity": "sha512-f4HigYjeIBn9f7OuNv5zh2y5vWaAhNFrfeul8CRJDy82l3Y+09lxOTGxfF3uMXKrZq4LmuK6qvvRCZ8mUrVvzQ==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-9.0.1.tgz",
+			"integrity": "sha512-fxnLadXs59qOBE9dInfQjQ4DmbGToQ0NjfqqmN6N8qS+KsCecO6N0mMUrC95et9xTeimFRr+0l9UMfmRVHNS/w==",
 			"dev": true
 		},
 		"@commitlint/format": {
-			"version": "8.3.4",
-			"resolved": "https://registry.npmjs.org/@commitlint/format/-/format-8.3.4.tgz",
-			"integrity": "sha512-809wlQ/ND6CLZON+w2Rb3YM2TLNDfU2xyyqpZeqzf2reJNpySMSUAeaO/fNDJSOKIsOsR3bI01rGu6hv28k+Nw==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/@commitlint/format/-/format-9.0.1.tgz",
+			"integrity": "sha512-5oY7Jyve7Bfnx0CdbxFcpRKq92vUANFq3MVbz/ZTgvuYgUeMuYsSEwW6MJtOgOhHBQ2vZP/uPdxwmU+6pWZHcg==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1"
+				"chalk": "^3.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"@commitlint/is-ignored": {
-			"version": "8.3.5",
-			"resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-8.3.5.tgz",
-			"integrity": "sha512-Zo+8a6gJLFDTqyNRx53wQi/XTiz8mncvmWf/4oRG+6WRcBfjSSHY7KPVj5Y6UaLy2EgZ0WQ2Tt6RdTDeQiQplA==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-9.0.1.tgz",
+			"integrity": "sha512-doGBfQgbsi48Hc48runGdN0TQFvf5XZizck8cylQdGG/3w+YwX9WkplEor7cvz8pmmuD6PpfpdukHSKlR8KmHQ==",
 			"dev": true,
 			"requires": {
-				"semver": "6.3.0"
+				"@commitlint/types": "^9.0.1",
+				"semver": "7.1.3"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "7.1.3",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
+					"integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA==",
+					"dev": true
+				}
 			}
 		},
 		"@commitlint/lint": {
-			"version": "8.3.5",
-			"resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-8.3.5.tgz",
-			"integrity": "sha512-02AkI0a6PU6rzqUvuDkSi6rDQ2hUgkq9GpmdJqfai5bDbxx2939mK4ZO+7apbIh4H6Pae7EpYi7ffxuJgm+3hQ==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-9.0.1.tgz",
+			"integrity": "sha512-EAn4E6aGWZ96Dg9LN28kdELqkyFOAUGlXWmanMdWxGFGdOf24ZHzlVsbr/Yb1oSBUE2KVvAF5W2Mzn2+Ge5rOg==",
 			"dev": true,
 			"requires": {
-				"@commitlint/is-ignored": "^8.3.5",
-				"@commitlint/parse": "^8.3.4",
-				"@commitlint/rules": "^8.3.4",
-				"babel-runtime": "^6.23.0",
-				"lodash": "4.17.15"
+				"@commitlint/is-ignored": "^9.0.1",
+				"@commitlint/parse": "^9.0.1",
+				"@commitlint/rules": "^9.0.1",
+				"@commitlint/types": "^9.0.1"
 			}
 		},
 		"@commitlint/load": {
-			"version": "8.3.5",
-			"resolved": "https://registry.npmjs.org/@commitlint/load/-/load-8.3.5.tgz",
-			"integrity": "sha512-poF7R1CtQvIXRmVIe63FjSQmN9KDqjRtU5A6hxqXBga87yB2VUJzic85TV6PcQc+wStk52cjrMI+g0zFx+Zxrw==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/@commitlint/load/-/load-9.0.1.tgz",
+			"integrity": "sha512-6ix/pUjVAggmDLTcnpyk0bgY3H9UBBTsEeFvTkHV+WQ6LNIxsQk8SwEOEZzWHUqt0pxqMQeiUgYeSZsSw2+uiw==",
 			"dev": true,
 			"requires": {
-				"@commitlint/execute-rule": "^8.3.4",
-				"@commitlint/resolve-extends": "^8.3.5",
-				"babel-runtime": "^6.23.0",
-				"chalk": "2.4.2",
-				"cosmiconfig": "^5.2.0",
-				"lodash": "4.17.15",
+				"@commitlint/execute-rule": "^9.0.1",
+				"@commitlint/resolve-extends": "^9.0.1",
+				"@commitlint/types": "^9.0.1",
+				"chalk": "3.0.0",
+				"cosmiconfig": "^6.0.0",
+				"lodash": "^4.17.15",
 				"resolve-from": "^5.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"@commitlint/message": {
-			"version": "8.3.4",
-			"resolved": "https://registry.npmjs.org/@commitlint/message/-/message-8.3.4.tgz",
-			"integrity": "sha512-nEj5tknoOKXqBsaQtCtgPcsAaf5VCg3+fWhss4Vmtq40633xLq0irkdDdMEsYIx8rGR0XPBTukqzln9kAWCkcA==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/@commitlint/message/-/message-9.0.1.tgz",
+			"integrity": "sha512-9rKnOeBV5s5hnV895aE3aMgciC27kAjkV9BYVQOWRjZdXHFZxa+OZ94mkMp+Hcr61W++fox1JJpPiTuCTDX3TQ==",
 			"dev": true
 		},
 		"@commitlint/parse": {
-			"version": "8.3.4",
-			"resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-8.3.4.tgz",
-			"integrity": "sha512-b3uQvpUQWC20EBfKSfMRnyx5Wc4Cn778bVeVOFErF/cXQK725L1bYFvPnEjQO/GT8yGVzq2wtLaoEqjm1NJ/Bw==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-9.0.1.tgz",
+			"integrity": "sha512-O39yMSMFdBtqwyM5Ld7RT6OGeI7jiXB9UUb09liIXIkltaZZo6CeoBD9hyfRWpaw81SiGL4OwHzp92mYVHLmow==",
 			"dev": true,
 			"requires": {
-				"conventional-changelog-angular": "^1.3.3",
-				"conventional-commits-parser": "^3.0.0",
-				"lodash": "^4.17.11"
+				"conventional-changelog-angular": "^5.0.0",
+				"conventional-commits-parser": "^3.0.0"
 			}
 		},
 		"@commitlint/read": {
-			"version": "8.3.4",
-			"resolved": "https://registry.npmjs.org/@commitlint/read/-/read-8.3.4.tgz",
-			"integrity": "sha512-FKv1kHPrvcAG5j+OSbd41IWexsbLhfIXpxVC/YwQZO+FR0EHmygxQNYs66r+GnhD1EfYJYM4WQIqd5bJRx6OIw==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/@commitlint/read/-/read-9.0.1.tgz",
+			"integrity": "sha512-EYbel85mAiHb56bS5jBJ71lEaGjTnkSJLxTV1u6dpxdSBkRdmAn2DSPd6KQSbwYGUlPCR+pAZeZItT1y0Xk3hg==",
 			"dev": true,
 			"requires": {
-				"@commitlint/top-level": "^8.3.4",
-				"@marionebl/sander": "^0.6.0",
-				"babel-runtime": "^6.23.0",
+				"@commitlint/top-level": "^9.0.1",
+				"fs-extra": "^8.1.0",
 				"git-raw-commits": "^2.0.0"
+			},
+			"dependencies": {
+				"fs-extra": {
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.2.0",
+						"jsonfile": "^4.0.0",
+						"universalify": "^0.1.0"
+					}
+				}
 			}
 		},
 		"@commitlint/resolve-extends": {
-			"version": "8.3.5",
-			"resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-8.3.5.tgz",
-			"integrity": "sha512-nHhFAK29qiXNe6oH6uG5wqBnCR+BQnxlBW/q5fjtxIaQALgfoNLHwLS9exzbIRFqwJckpR6yMCfgMbmbAOtklQ==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-9.0.1.tgz",
+			"integrity": "sha512-o6Lya2ILg1tEfWatS5x8w4ImvDzwb1whxsr2c/cxVCFqLF4hxHHHniZ0NJ+HFhYa1kBsYeKlD1qn9fHX5Y1+PQ==",
 			"dev": true,
 			"requires": {
 				"import-fresh": "^3.0.0",
-				"lodash": "4.17.15",
+				"lodash": "^4.17.15",
 				"resolve-from": "^5.0.0",
 				"resolve-global": "^1.0.0"
 			}
 		},
 		"@commitlint/rules": {
-			"version": "8.3.4",
-			"resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-8.3.4.tgz",
-			"integrity": "sha512-xuC9dlqD5xgAoDFgnbs578cJySvwOSkMLQyZADb1xD5n7BNcUJfP8WjT9W1Aw8K3Wf8+Ym/ysr9FZHXInLeaRg==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-9.0.1.tgz",
+			"integrity": "sha512-K9IiQzF/C2tP/0mQUPSkOtmAEUleRQhZK1NFLVbsd6r4uobaczjPSYvEH+cuSHlD9b3Ori7PRiTgVBAZTH5ORQ==",
 			"dev": true,
 			"requires": {
-				"@commitlint/ensure": "^8.3.4",
-				"@commitlint/message": "^8.3.4",
-				"@commitlint/to-lines": "^8.3.4",
-				"babel-runtime": "^6.23.0"
+				"@commitlint/ensure": "^9.0.1",
+				"@commitlint/message": "^9.0.1",
+				"@commitlint/to-lines": "^9.0.1",
+				"@commitlint/types": "^9.0.1"
 			}
 		},
 		"@commitlint/to-lines": {
-			"version": "8.3.4",
-			"resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-8.3.4.tgz",
-			"integrity": "sha512-5AvcdwRsMIVq0lrzXTwpbbG5fKRTWcHkhn/hCXJJ9pm1JidsnidS1y0RGkb3O50TEHGewhXwNoavxW9VToscUA==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-9.0.1.tgz",
+			"integrity": "sha512-FHiXPhFgGnvekF4rhyl1daHimEHkr81pxbHAmWG/0SOCehFr5THsWGoUYNNBMF7rdwUuVq4tXJpEOFiWBGKigg==",
 			"dev": true
 		},
 		"@commitlint/top-level": {
-			"version": "8.3.4",
-			"resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-8.3.4.tgz",
-			"integrity": "sha512-nOaeLBbAqSZNpKgEtO6NAxmui1G8ZvLG+0wb4rvv6mWhPDzK1GNZkCd8FUZPahCoJ1iHDoatw7F8BbJLg4nDjg==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-9.0.1.tgz",
+			"integrity": "sha512-AjCah5y7wu9F/hOwMnqsujPRWlKerX79ZGf+UfBpOdAh+USdV7a/UfQaqjgCzkxy5GcNO9ER5A+2mWrUHxJ0hQ==",
 			"dev": true,
 			"requires": {
 				"find-up": "^4.0.0"
@@ -1311,16 +1717,11 @@
 				}
 			}
 		},
-		"@marionebl/sander": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/@marionebl/sander/-/sander-0.6.1.tgz",
-			"integrity": "sha1-GViWWHTyS8Ub5Ih1/rUNZC/EH3s=",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "^4.1.3",
-				"mkdirp": "^0.5.1",
-				"rimraf": "^2.5.2"
-			}
+		"@commitlint/types": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/@commitlint/types/-/types-9.0.1.tgz",
+			"integrity": "sha512-wo2rHprtDzTHf4tiSxavktJ52ntiwmg7eHNGFLH38G1of8OfGVwOc1sVbpM4jN/HK/rCMhYOi6xzoPqsv0537A==",
+			"dev": true
 		},
 		"@neovici/cosmoz-bottom-bar": {
 			"version": "3.0.10",
@@ -1388,6 +1789,94 @@
 				"eslint-plugin-html": "^6.0.2",
 				"eslint-plugin-import": "^2.20.2",
 				"eslint-plugin-mocha": "^6.3.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
+				},
+				"eslint": {
+					"version": "6.8.0",
+					"resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
+					"integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"ajv": "^6.10.0",
+						"chalk": "^2.1.0",
+						"cross-spawn": "^6.0.5",
+						"debug": "^4.0.1",
+						"doctrine": "^3.0.0",
+						"eslint-scope": "^5.0.0",
+						"eslint-utils": "^1.4.3",
+						"eslint-visitor-keys": "^1.1.0",
+						"espree": "^6.1.2",
+						"esquery": "^1.0.1",
+						"esutils": "^2.0.2",
+						"file-entry-cache": "^5.0.1",
+						"functional-red-black-tree": "^1.0.1",
+						"glob-parent": "^5.0.0",
+						"globals": "^12.1.0",
+						"ignore": "^4.0.6",
+						"import-fresh": "^3.0.0",
+						"imurmurhash": "^0.1.4",
+						"inquirer": "^7.0.0",
+						"is-glob": "^4.0.0",
+						"js-yaml": "^3.13.1",
+						"json-stable-stringify-without-jsonify": "^1.0.1",
+						"levn": "^0.3.0",
+						"lodash": "^4.17.14",
+						"minimatch": "^3.0.4",
+						"mkdirp": "^0.5.1",
+						"natural-compare": "^1.4.0",
+						"optionator": "^0.8.3",
+						"progress": "^2.0.0",
+						"regexpp": "^2.0.1",
+						"semver": "^6.1.2",
+						"strip-ansi": "^5.2.0",
+						"strip-json-comments": "^3.0.1",
+						"table": "^5.2.3",
+						"text-table": "^0.2.0",
+						"v8-compile-cache": "^2.0.3"
+					}
+				},
+				"espree": {
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+					"integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
+					"dev": true,
+					"requires": {
+						"acorn": "^7.1.1",
+						"acorn-jsx": "^5.2.0",
+						"eslint-visitor-keys": "^1.1.0"
+					}
+				},
+				"globals": {
+					"version": "12.4.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+					"integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+					"dev": true,
+					"requires": {
+						"type-fest": "^0.8.1"
+					}
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
+				},
+				"strip-json-comments": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
+					"integrity": "sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==",
+					"dev": true
+				}
 			}
 		},
 		"@nodelib/fs.scandir": {
@@ -2968,6 +3457,12 @@
 				"negotiator": "0.6.2"
 			}
 		},
+		"acorn": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
+			"integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==",
+			"dev": true
+		},
 		"acorn-jsx": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
@@ -3318,43 +3813,6 @@
 				}
 			}
 		},
-		"babel-polyfill": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
-			"integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.26.0",
-				"core-js": "^2.5.0",
-				"regenerator-runtime": "^0.10.5"
-			},
-			"dependencies": {
-				"regenerator-runtime": {
-					"version": "0.10.5",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-					"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
-					"dev": true
-				}
-			}
-		},
-		"babel-runtime": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-			"dev": true,
-			"requires": {
-				"core-js": "^2.4.0",
-				"regenerator-runtime": "^0.11.0"
-			},
-			"dependencies": {
-				"regenerator-runtime": {
-					"version": "0.11.1",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-					"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-					"dev": true
-				}
-			}
-		},
 		"backo2": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
@@ -3599,32 +4057,6 @@
 				"ylru": "^1.2.0"
 			}
 		},
-		"caller-callsite": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
-			"integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
-			"dev": true,
-			"requires": {
-				"callsites": "^2.0.0"
-			},
-			"dependencies": {
-				"callsites": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
-					"dev": true
-				}
-			}
-		},
-		"caller-path": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
-			"integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
-			"dev": true,
-			"requires": {
-				"caller-callsite": "^2.0.0"
-			}
-		},
 		"callsite": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
@@ -3813,6 +4245,15 @@
 			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
 			"dev": true
 		},
+		"cli-cursor": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+			"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+			"dev": true,
+			"requires": {
+				"restore-cursor": "^3.1.0"
+			}
+		},
 		"cli-table": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
@@ -3831,9 +4272,9 @@
 			}
 		},
 		"cli-width": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+			"integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
 			"dev": true
 		},
 		"cliui": {
@@ -4067,9 +4508,9 @@
 			"dev": true
 		},
 		"conventional-changelog-angular": {
-			"version": "1.6.6",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz",
-			"integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.10.tgz",
+			"integrity": "sha512-k7RPPRs0vp8+BtPsM9uDxRl6KcgqtCJmzRD1wRtgqmhQ96g8ifBGo9O/TZBG23jqlXS/rg8BKRDELxfnQQGiaA==",
 			"dev": true,
 			"requires": {
 				"compare-func": "^1.3.1",
@@ -4077,13 +4518,13 @@
 			}
 		},
 		"conventional-changelog-conventionalcommits": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.2.1.tgz",
-			"integrity": "sha512-vC02KucnkNNap+foDKFm7BVUSDAXktXrUJqGszUuYnt6T0J2azsbYz/w9TDc3VsrW2v6JOtiQWVcgZnporHr4Q==",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.2.3.tgz",
+			"integrity": "sha512-atGa+R4vvEhb8N/8v3IoW59gCBJeeFiX6uIbPu876ENAmkMwsenyn0R21kdDHJFLQdy6zW4J6b4xN8KI3b9oww==",
 			"dev": true,
 			"requires": {
 				"compare-func": "^1.3.1",
-				"lodash": "^4.2.1",
+				"lodash": "^4.17.15",
 				"q": "^1.5.1"
 			}
 		},
@@ -4404,9 +4845,9 @@
 			}
 		},
 		"core-js": {
-			"version": "2.6.11",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-			"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+			"version": "3.6.5",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+			"integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
 			"dev": true
 		},
 		"core-js-bundle": {
@@ -4440,31 +4881,34 @@
 			"dev": true
 		},
 		"cosmiconfig": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
-			"integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+			"integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
 			"dev": true,
 			"requires": {
-				"import-fresh": "^2.0.0",
-				"is-directory": "^0.3.1",
-				"js-yaml": "^3.13.1",
-				"parse-json": "^4.0.0"
+				"@types/parse-json": "^4.0.0",
+				"import-fresh": "^3.1.0",
+				"parse-json": "^5.0.0",
+				"path-type": "^4.0.0",
+				"yaml": "^1.7.2"
 			},
 			"dependencies": {
-				"import-fresh": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
-					"integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+				"parse-json": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+					"integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
 					"dev": true,
 					"requires": {
-						"caller-path": "^2.0.0",
-						"resolve-from": "^3.0.0"
+						"@babel/code-frame": "^7.0.0",
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1",
+						"lines-and-columns": "^1.1.6"
 					}
 				},
-				"resolve-from": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+				"path-type": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
 					"dev": true
 				}
 			}
@@ -4512,13 +4956,10 @@
 			"dev": true
 		},
 		"dargs": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
-			"integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
-			"dev": true,
-			"requires": {
-				"number-is-nan": "^1.0.0"
-			}
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz",
+			"integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==",
+			"dev": true
 		},
 		"dashdash": {
 			"version": "1.14.1",
@@ -4894,6 +5335,15 @@
 				"has-binary2": "~1.0.2"
 			}
 		},
+		"enquirer": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.5.tgz",
+			"integrity": "sha512-BNT1C08P9XD0vNg3J475yIUG+mVdp9T6towYFHUv897X0KoHBjB1shyrNmhmtHWKP17iSWgo7Gqh7BBuzLZMSA==",
+			"dev": true,
+			"requires": {
+				"ansi-colors": "^3.2.1"
+			}
+		},
 		"ent": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
@@ -5088,22 +5538,23 @@
 			"dev": true
 		},
 		"eslint": {
-			"version": "6.8.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
-			"integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.3.0.tgz",
+			"integrity": "sha512-dJMVXwfU5PT1cj2Nv2VPPrKahKTGdX+5Dh0Q3YuKt+Y2UhdL2YbzsVaBMyG9HC0tBismlv/r1+eZqs6SMIV38Q==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
 				"ajv": "^6.10.0",
-				"chalk": "^2.1.0",
-				"cross-spawn": "^6.0.5",
+				"chalk": "^4.0.0",
+				"cross-spawn": "^7.0.2",
 				"debug": "^4.0.1",
 				"doctrine": "^3.0.0",
-				"eslint-scope": "^5.0.0",
-				"eslint-utils": "^1.4.3",
-				"eslint-visitor-keys": "^1.1.0",
-				"espree": "^6.1.2",
-				"esquery": "^1.0.1",
+				"enquirer": "^2.3.5",
+				"eslint-scope": "^5.1.0",
+				"eslint-utils": "^2.0.0",
+				"eslint-visitor-keys": "^1.2.0",
+				"espree": "^7.1.0",
+				"esquery": "^1.2.0",
 				"esutils": "^2.0.2",
 				"file-entry-cache": "^5.0.1",
 				"functional-red-black-tree": "^1.0.1",
@@ -5112,49 +5563,24 @@
 				"ignore": "^4.0.6",
 				"import-fresh": "^3.0.0",
 				"imurmurhash": "^0.1.4",
-				"inquirer": "^7.0.0",
 				"is-glob": "^4.0.0",
 				"js-yaml": "^3.13.1",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
-				"levn": "^0.3.0",
+				"levn": "^0.4.1",
 				"lodash": "^4.17.14",
 				"minimatch": "^3.0.4",
-				"mkdirp": "^0.5.1",
 				"natural-compare": "^1.4.0",
-				"optionator": "^0.8.3",
+				"optionator": "^0.9.1",
 				"progress": "^2.0.0",
-				"regexpp": "^2.0.1",
-				"semver": "^6.1.2",
-				"strip-ansi": "^5.2.0",
-				"strip-json-comments": "^3.0.1",
+				"regexpp": "^3.1.0",
+				"semver": "^7.2.1",
+				"strip-ansi": "^6.0.0",
+				"strip-json-comments": "^3.1.0",
 				"table": "^5.2.3",
 				"text-table": "^0.2.0",
 				"v8-compile-cache": "^2.0.3"
 			},
 			"dependencies": {
-				"acorn": {
-					"version": "7.1.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-					"integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
-					"dev": true
-				},
-				"ansi-escapes": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
-					"integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
-					"dev": true,
-					"requires": {
-						"type-fest": "^0.11.0"
-					},
-					"dependencies": {
-						"type-fest": {
-							"version": "0.11.0",
-							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-							"integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
-							"dev": true
-						}
-					}
-				},
 				"ansi-regex": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
@@ -5171,13 +5597,14 @@
 						"color-convert": "^2.0.1"
 					}
 				},
-				"cli-cursor": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-					"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 					"dev": true,
 					"requires": {
-						"restore-cursor": "^3.1.0"
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
 					}
 				},
 				"color-convert": {
@@ -5195,40 +5622,41 @@
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 					"dev": true
 				},
-				"emoji-regex": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-					"dev": true
-				},
-				"eslint-scope": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
-					"integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+				"cross-spawn": {
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+					"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
 					"dev": true,
 					"requires": {
-						"esrecurse": "^4.1.0",
-						"estraverse": "^4.1.1"
+						"path-key": "^3.1.0",
+						"shebang-command": "^2.0.0",
+						"which": "^2.0.1"
 					}
 				},
-				"espree": {
-					"version": "6.2.1",
-					"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
-					"integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
+				"eslint-utils": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+					"integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
 					"dev": true,
 					"requires": {
-						"acorn": "^7.1.1",
-						"acorn-jsx": "^5.2.0",
 						"eslint-visitor-keys": "^1.1.0"
 					}
 				},
-				"figures": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-					"integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+				"eslint-visitor-keys": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+					"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+					"dev": true
+				},
+				"espree": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/espree/-/espree-7.1.0.tgz",
+					"integrity": "sha512-dcorZSyfmm4WTuTnE5Y7MEN1DyoPYy1ZR783QW1FJoenn7RailyWFsq/UL6ZAAA7uXurN9FIpYyUs3OfiIW+Qw==",
 					"dev": true,
 					"requires": {
-						"escape-string-regexp": "^1.0.5"
+						"acorn": "^7.2.0",
+						"acorn-jsx": "^5.2.0",
+						"eslint-visitor-keys": "^1.2.0"
 					}
 				},
 				"globals": {
@@ -5246,122 +5674,76 @@
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 					"dev": true
 				},
-				"inquirer": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
-					"integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
+				"levn": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+					"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
 					"dev": true,
 					"requires": {
-						"ansi-escapes": "^4.2.1",
-						"chalk": "^3.0.0",
-						"cli-cursor": "^3.1.0",
-						"cli-width": "^2.0.0",
-						"external-editor": "^3.0.3",
-						"figures": "^3.0.0",
-						"lodash": "^4.17.15",
-						"mute-stream": "0.0.8",
-						"run-async": "^2.4.0",
-						"rxjs": "^6.5.3",
-						"string-width": "^4.1.0",
-						"strip-ansi": "^6.0.0",
-						"through": "^2.3.6"
-					},
-					"dependencies": {
-						"chalk": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^4.1.0",
-								"supports-color": "^7.1.0"
-							}
-						},
-						"strip-ansi": {
-							"version": "6.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-							"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-							"dev": true,
-							"requires": {
-								"ansi-regex": "^5.0.0"
-							}
-						}
+						"prelude-ls": "^1.2.1",
+						"type-check": "~0.4.0"
 					}
 				},
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-					"dev": true
-				},
-				"mimic-fn": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-					"dev": true
-				},
-				"mute-stream": {
-					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-					"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-					"dev": true
-				},
-				"onetime": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-					"integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+				"optionator": {
+					"version": "0.9.1",
+					"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+					"integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
 					"dev": true,
 					"requires": {
-						"mimic-fn": "^2.1.0"
+						"deep-is": "^0.1.3",
+						"fast-levenshtein": "^2.0.6",
+						"levn": "^0.4.1",
+						"prelude-ls": "^1.2.1",
+						"type-check": "^0.4.0",
+						"word-wrap": "^1.2.3"
 					}
 				},
-				"restore-cursor": {
+				"path-key": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+					"dev": true
+				},
+				"prelude-ls": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+					"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+					"dev": true
+				},
+				"regexpp": {
 					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-					"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+					"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+					"integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+					"dev": true
+				},
+				"semver": {
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+					"dev": true
+				},
+				"shebang-command": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
 					"dev": true,
 					"requires": {
-						"onetime": "^5.1.0",
-						"signal-exit": "^3.0.2"
+						"shebang-regex": "^3.0.0"
 					}
 				},
-				"string-width": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.0"
-					},
-					"dependencies": {
-						"strip-ansi": {
-							"version": "6.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-							"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-							"dev": true,
-							"requires": {
-								"ansi-regex": "^5.0.0"
-							}
-						}
-					}
+				"shebang-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+					"dev": true
 				},
 				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^4.1.0"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "4.1.0",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-							"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-							"dev": true
-						}
+						"ansi-regex": "^5.0.0"
 					}
 				},
 				"strip-json-comments": {
@@ -5377,6 +5759,24 @@
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
+					}
+				},
+				"type-check": {
+					"version": "0.4.0",
+					"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+					"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+					"dev": true,
+					"requires": {
+						"prelude-ls": "^1.2.1"
+					}
+				},
+				"which": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
 					}
 				}
 			}
@@ -5579,6 +5979,16 @@
 				}
 			}
 		},
+		"eslint-scope": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
+			"integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
+			"dev": true,
+			"requires": {
+				"esrecurse": "^4.1.0",
+				"estraverse": "^4.1.1"
+			}
+		},
 		"eslint-utils": {
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
@@ -5601,18 +6011,18 @@
 			"dev": true
 		},
 		"esquery": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.2.0.tgz",
-			"integrity": "sha512-weltsSqdeWIX9G2qQZz7KlTRJdkkOCTPgLYJUz1Hacf48R4YOwGPHO3+ORfWedqJKbq5WQmsgK90n+pFLIKt/Q==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
+			"integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
 			"dev": true,
 			"requires": {
-				"estraverse": "^5.0.0"
+				"estraverse": "^5.1.0"
 			},
 			"dependencies": {
 				"estraverse": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.0.0.tgz",
-					"integrity": "sha512-j3acdrMzqrxmJTNj5dbr1YbjacrYgAxVMeF0gK16E3j494mOe7xygM/ZLIguEQ0ETwAg2hlJCtHRGav+y0Ny5A==",
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.1.0.tgz",
+					"integrity": "sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==",
 					"dev": true
 				}
 			}
@@ -6095,16 +6505,256 @@
 			}
 		},
 		"git-raw-commits": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.3.tgz",
-			"integrity": "sha512-SoSsFL5lnixVzctGEi2uykjA7B5I0AhO9x6kdzvGRHbxsa6JSEgrgy1esRKsfOKE1cgyOJ/KDR2Trxu157sb8w==",
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.7.tgz",
+			"integrity": "sha512-SkwrTqrDxw8y0G1uGJ9Zw13F7qu3LF8V4BifyDeiJCxSnjRGZD9SaoMiMqUvvXMXh6S3sOQ1DsBN7L2fMUZW/g==",
 			"dev": true,
 			"requires": {
-				"dargs": "^4.0.1",
+				"dargs": "^7.0.0",
 				"lodash.template": "^4.0.2",
-				"meow": "^5.0.0",
+				"meow": "^7.0.0",
 				"split2": "^2.0.0",
 				"through2": "^3.0.0"
+			},
+			"dependencies": {
+				"arrify": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+					"integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+					"dev": true
+				},
+				"camelcase": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
+					"integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
+					"dev": true
+				},
+				"camelcase-keys": {
+					"version": "6.2.2",
+					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+					"integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.3.1",
+						"map-obj": "^4.0.0",
+						"quick-lru": "^4.0.1"
+					},
+					"dependencies": {
+						"camelcase": {
+							"version": "5.3.1",
+							"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+							"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+							"dev": true
+						}
+					}
+				},
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"indent-string": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+					"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+					"dev": true
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"map-obj": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
+					"integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==",
+					"dev": true
+				},
+				"meow": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/meow/-/meow-7.0.1.tgz",
+					"integrity": "sha512-tBKIQqVrAHqwit0vfuFPY3LlzJYkEOFyKa3bPgxzNl6q/RtN8KQ+ALYEASYuFayzSAsjlhXj/JZ10rH85Q6TUw==",
+					"dev": true,
+					"requires": {
+						"@types/minimist": "^1.2.0",
+						"arrify": "^2.0.1",
+						"camelcase": "^6.0.0",
+						"camelcase-keys": "^6.2.2",
+						"decamelize-keys": "^1.1.0",
+						"hard-rejection": "^2.1.0",
+						"minimist-options": "^4.0.2",
+						"normalize-package-data": "^2.5.0",
+						"read-pkg-up": "^7.0.1",
+						"redent": "^3.0.0",
+						"trim-newlines": "^3.0.0",
+						"type-fest": "^0.13.1",
+						"yargs-parser": "^18.1.3"
+					}
+				},
+				"minimist-options": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+					"integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
+					"dev": true,
+					"requires": {
+						"arrify": "^1.0.1",
+						"is-plain-obj": "^1.1.0",
+						"kind-of": "^6.0.3"
+					},
+					"dependencies": {
+						"arrify": {
+							"version": "1.0.1",
+							"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+							"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+							"dev": true
+						}
+					}
+				},
+				"p-limit": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
+				},
+				"parse-json": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+					"integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1",
+						"lines-and-columns": "^1.1.6"
+					}
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				},
+				"quick-lru": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+					"integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+					"dev": true
+				},
+				"read-pkg": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+					"integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+					"dev": true,
+					"requires": {
+						"@types/normalize-package-data": "^2.4.0",
+						"normalize-package-data": "^2.5.0",
+						"parse-json": "^5.0.0",
+						"type-fest": "^0.6.0"
+					},
+					"dependencies": {
+						"type-fest": {
+							"version": "0.6.0",
+							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+							"integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+							"dev": true
+						}
+					}
+				},
+				"read-pkg-up": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+					"integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+					"dev": true,
+					"requires": {
+						"find-up": "^4.1.0",
+						"read-pkg": "^5.2.0",
+						"type-fest": "^0.8.1"
+					},
+					"dependencies": {
+						"type-fest": {
+							"version": "0.8.1",
+							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+							"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+							"dev": true
+						}
+					}
+				},
+				"redent": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+					"integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+					"dev": true,
+					"requires": {
+						"indent-string": "^4.0.0",
+						"strip-indent": "^3.0.0"
+					}
+				},
+				"strip-indent": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+					"integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+					"dev": true,
+					"requires": {
+						"min-indent": "^1.0.0"
+					}
+				},
+				"trim-newlines": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
+					"integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
+					"dev": true
+				},
+				"type-fest": {
+					"version": "0.13.1",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+					"integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+					"dev": true
+				},
+				"yargs-parser": {
+					"version": "18.1.3",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+					"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					},
+					"dependencies": {
+						"camelcase": {
+							"version": "5.3.1",
+							"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+							"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+							"dev": true
+						}
+					}
+				}
 			}
 		},
 		"glob": {
@@ -6680,6 +7330,117 @@
 			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
 			"dev": true
 		},
+		"inquirer": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.2.0.tgz",
+			"integrity": "sha512-E0c4rPwr9ByePfNlTIB8z51kK1s2n6jrHuJeEHENl/sbq2G/S1auvibgEwNR4uSyiU+PiYHqSwsgGiXjG8p5ZQ==",
+			"dev": true,
+			"requires": {
+				"ansi-escapes": "^4.2.1",
+				"chalk": "^3.0.0",
+				"cli-cursor": "^3.1.0",
+				"cli-width": "^2.0.0",
+				"external-editor": "^3.0.3",
+				"figures": "^3.0.0",
+				"lodash": "^4.17.15",
+				"mute-stream": "0.0.8",
+				"run-async": "^2.4.0",
+				"rxjs": "^6.5.3",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0",
+				"through": "^2.3.6"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
 		"intersection-observer": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.7.0.tgz",
@@ -6760,12 +7521,6 @@
 			"integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
 			"dev": true
 		},
-		"is-directory": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
-			"integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
-			"dev": true
-		},
 		"is-docker": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.0.0.tgz",
@@ -6837,12 +7592,6 @@
 			"requires": {
 				"isobject": "^4.0.0"
 			}
-		},
-		"is-promise": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-			"dev": true
 		},
 		"is-regex": {
 			"version": "1.1.0",
@@ -8292,6 +9041,12 @@
 				"mime-db": "1.44.0"
 			}
 		},
+		"mimic-fn": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+			"dev": true
+		},
 		"min-indent": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -8481,6 +9236,12 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+			"dev": true
+		},
+		"mute-stream": {
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
 			"dev": true
 		},
 		"mz": {
@@ -8750,7 +9511,8 @@
 			"dependencies": {
 				"JSONStream": {
 					"version": "1.3.5",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
 					"dev": true,
 					"requires": {
 						"jsonparse": "^1.2.0",
@@ -8759,12 +9521,14 @@
 				},
 				"abbrev": {
 					"version": "1.1.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 					"dev": true
 				},
 				"agent-base": {
 					"version": "4.3.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
 					"dev": true,
 					"requires": {
 						"es6-promisify": "^5.0.0"
@@ -8772,7 +9536,8 @@
 				},
 				"agentkeepalive": {
 					"version": "3.5.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==",
 					"dev": true,
 					"requires": {
 						"humanize-ms": "^1.2.1"
@@ -8780,7 +9545,8 @@
 				},
 				"ajv": {
 					"version": "5.5.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 					"dev": true,
 					"requires": {
 						"co": "^4.6.0",
@@ -8791,7 +9557,8 @@
 				},
 				"ansi-align": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
 					"dev": true,
 					"requires": {
 						"string-width": "^2.0.0"
@@ -8799,12 +9566,14 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
 					"dev": true
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
@@ -8812,27 +9581,32 @@
 				},
 				"ansicolors": {
 					"version": "0.3.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
 					"dev": true
 				},
 				"ansistyles": {
 					"version": "0.1.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
 					"dev": true
 				},
 				"aproba": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
 					"dev": true
 				},
 				"archy": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
 					"dev": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
 					"dev": true,
 					"requires": {
 						"delegates": "^1.0.0",
@@ -8841,7 +9615,8 @@
 					"dependencies": {
 						"readable-stream": {
 							"version": "2.3.6",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 							"dev": true,
 							"requires": {
 								"core-util-is": "~1.0.0",
@@ -8855,7 +9630,8 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 							"dev": true,
 							"requires": {
 								"safe-buffer": "~5.1.0"
@@ -8865,12 +9641,14 @@
 				},
 				"asap": {
 					"version": "2.0.6",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
 					"dev": true
 				},
 				"asn1": {
 					"version": "0.2.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
 					"dev": true,
 					"requires": {
 						"safer-buffer": "~2.1.0"
@@ -8878,32 +9656,38 @@
 				},
 				"assert-plus": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
 					"dev": true
 				},
 				"asynckit": {
 					"version": "0.4.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
 					"dev": true
 				},
 				"aws-sign2": {
 					"version": "0.7.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
 					"dev": true
 				},
 				"aws4": {
 					"version": "1.8.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
 					"dev": true
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 					"dev": true
 				},
 				"bcrypt-pbkdf": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8912,7 +9696,8 @@
 				},
 				"bin-links": {
 					"version": "1.1.7",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-/eaLaTu7G7/o7PV04QPy1HRT65zf+1tFkPGv0sPTV0tRwufooYBQO3zrcyGgm+ja+ZtBf2GEuKjDRJ2pPG+yqA==",
 					"dev": true,
 					"requires": {
 						"bluebird": "^3.5.3",
@@ -8925,12 +9710,14 @@
 				},
 				"bluebird": {
 					"version": "3.5.5",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
 					"dev": true
 				},
 				"boxen": {
 					"version": "1.3.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
 					"dev": true,
 					"requires": {
 						"ansi-align": "^2.0.0",
@@ -8944,7 +9731,8 @@
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 					"dev": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
@@ -8953,27 +9741,32 @@
 				},
 				"buffer-from": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
 					"dev": true
 				},
 				"builtins": {
 					"version": "1.0.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
 					"dev": true
 				},
 				"byline": {
 					"version": "5.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
 					"dev": true
 				},
 				"byte-size": {
 					"version": "5.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-/XuKeqWocKsYa/cBY1YbSJSWWqTi4cFgr9S6OyM7PBaPbr9zvNGwWP33vt0uqGhwDdN+y3yhbXVILEUpnwEWGw==",
 					"dev": true
 				},
 				"cacache": {
 					"version": "12.0.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
 					"dev": true,
 					"requires": {
 						"bluebird": "^3.5.5",
@@ -8995,27 +9788,32 @@
 				},
 				"call-limit": {
 					"version": "1.1.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-5twvci5b9eRBw2wCfPtN0GmlR2/gadZqyFpPhOK6CvMFoFgA+USnZ6Jpu1lhG9h85pQ3Ouil3PfXWRD4EUaRiQ==",
 					"dev": true
 				},
 				"camelcase": {
 					"version": "4.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
 					"dev": true
 				},
 				"capture-stack-trace": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
 					"dev": true
 				},
 				"caseless": {
 					"version": "0.12.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
 					"dev": true
 				},
 				"chalk": {
 					"version": "2.4.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
@@ -9025,17 +9823,20 @@
 				},
 				"chownr": {
 					"version": "1.1.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
 					"dev": true
 				},
 				"ci-info": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
 					"dev": true
 				},
 				"cidr-regex": {
 					"version": "2.0.10",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-sB3ogMQXWvreNPbJUZMRApxuRYd+KoIo4RGQ81VatjmMW6WJPo+IJZ2846FGItr9VzKo5w7DXzijPLGtSd0N3Q==",
 					"dev": true,
 					"requires": {
 						"ip-regex": "^2.1.0"
@@ -9043,12 +9844,14 @@
 				},
 				"cli-boxes": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
 					"dev": true
 				},
 				"cli-columns": {
 					"version": "3.1.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-ZzLZcpee/CrkRKHwjgj6E5yWoY4=",
 					"dev": true,
 					"requires": {
 						"string-width": "^2.0.0",
@@ -9057,7 +9860,8 @@
 				},
 				"cli-table3": {
 					"version": "0.5.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
 					"dev": true,
 					"requires": {
 						"colors": "^1.1.2",
@@ -9067,7 +9871,8 @@
 				},
 				"cliui": {
 					"version": "4.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
 					"dev": true,
 					"requires": {
 						"string-width": "^2.1.1",
@@ -9077,12 +9882,14 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "3.0.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
 							"dev": true
 						},
 						"strip-ansi": {
 							"version": "4.0.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 							"dev": true,
 							"requires": {
 								"ansi-regex": "^3.0.0"
@@ -9092,12 +9899,14 @@
 				},
 				"clone": {
 					"version": "1.0.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
 					"dev": true
 				},
 				"cmd-shim": {
 					"version": "3.0.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-DtGg+0xiFhQIntSBRzL2fRQBnmtAVwXIDo4Qq46HPpObYquxMaZS4sb82U9nH91qJrlosC1wa9gwr0QyL/HypA==",
 					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
@@ -9106,17 +9915,20 @@
 				},
 				"co": {
 					"version": "4.6.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
 					"dev": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
 					"dev": true
 				},
 				"color-convert": {
 					"version": "1.9.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
 					"dev": true,
 					"requires": {
 						"color-name": "^1.1.1"
@@ -9124,18 +9936,21 @@
 				},
 				"color-name": {
 					"version": "1.1.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 					"dev": true
 				},
 				"colors": {
 					"version": "1.3.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
 					"dev": true,
 					"optional": true
 				},
 				"columnify": {
 					"version": "1.5.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
 					"dev": true,
 					"requires": {
 						"strip-ansi": "^3.0.0",
@@ -9144,7 +9959,8 @@
 				},
 				"combined-stream": {
 					"version": "1.0.6",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
 					"dev": true,
 					"requires": {
 						"delayed-stream": "~1.0.0"
@@ -9152,12 +9968,14 @@
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 					"dev": true
 				},
 				"concat-stream": {
 					"version": "1.6.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
 					"dev": true,
 					"requires": {
 						"buffer-from": "^1.0.0",
@@ -9168,7 +9986,8 @@
 					"dependencies": {
 						"readable-stream": {
 							"version": "2.3.6",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 							"dev": true,
 							"requires": {
 								"core-util-is": "~1.0.0",
@@ -9182,7 +10001,8 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 							"dev": true,
 							"requires": {
 								"safe-buffer": "~5.1.0"
@@ -9192,7 +10012,8 @@
 				},
 				"config-chain": {
 					"version": "1.1.12",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
 					"dev": true,
 					"requires": {
 						"ini": "^1.3.4",
@@ -9201,7 +10022,8 @@
 				},
 				"configstore": {
 					"version": "3.1.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
 					"dev": true,
 					"requires": {
 						"dot-prop": "^4.1.0",
@@ -9214,12 +10036,14 @@
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
 					"dev": true
 				},
 				"copy-concurrently": {
 					"version": "1.0.5",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
 					"dev": true,
 					"requires": {
 						"aproba": "^1.1.1",
@@ -9232,24 +10056,28 @@
 					"dependencies": {
 						"aproba": {
 							"version": "1.2.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
 							"dev": true
 						},
 						"iferr": {
 							"version": "0.1.5",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
 							"dev": true
 						}
 					}
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 					"dev": true
 				},
 				"create-error-class": {
 					"version": "3.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
 					"dev": true,
 					"requires": {
 						"capture-stack-trace": "^1.0.0"
@@ -9257,7 +10085,8 @@
 				},
 				"cross-spawn": {
 					"version": "5.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 					"dev": true,
 					"requires": {
 						"lru-cache": "^4.0.1",
@@ -9267,7 +10096,8 @@
 					"dependencies": {
 						"lru-cache": {
 							"version": "4.1.5",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
 							"dev": true,
 							"requires": {
 								"pseudomap": "^1.0.2",
@@ -9276,24 +10106,28 @@
 						},
 						"yallist": {
 							"version": "2.1.2",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
 							"dev": true
 						}
 					}
 				},
 				"crypto-random-string": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
 					"dev": true
 				},
 				"cyclist": {
 					"version": "0.2.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
 					"dev": true
 				},
 				"dashdash": {
 					"version": "1.14.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 					"dev": true,
 					"requires": {
 						"assert-plus": "^1.0.0"
@@ -9301,7 +10135,8 @@
 				},
 				"debug": {
 					"version": "3.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -9309,34 +10144,40 @@
 					"dependencies": {
 						"ms": {
 							"version": "2.0.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 							"dev": true
 						}
 					}
 				},
 				"debuglog": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
 					"dev": true
 				},
 				"decamelize": {
 					"version": "1.2.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 					"dev": true
 				},
 				"decode-uri-component": {
 					"version": "0.2.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
 					"dev": true
 				},
 				"deep-extend": {
 					"version": "0.6.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
 					"dev": true
 				},
 				"defaults": {
 					"version": "1.0.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
 					"dev": true,
 					"requires": {
 						"clone": "^1.0.2"
@@ -9344,7 +10185,8 @@
 				},
 				"define-properties": {
 					"version": "1.1.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
 					"dev": true,
 					"requires": {
 						"object-keys": "^1.0.12"
@@ -9352,27 +10194,32 @@
 				},
 				"delayed-stream": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
 					"dev": true
 				},
 				"delegates": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
 					"dev": true
 				},
 				"detect-indent": {
 					"version": "5.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
 					"dev": true
 				},
 				"detect-newline": {
 					"version": "2.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
 					"dev": true
 				},
 				"dezalgo": {
 					"version": "1.0.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
 					"dev": true,
 					"requires": {
 						"asap": "^2.0.0",
@@ -9381,7 +10228,8 @@
 				},
 				"dot-prop": {
 					"version": "4.2.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
 					"dev": true,
 					"requires": {
 						"is-obj": "^1.0.0"
@@ -9389,17 +10237,20 @@
 				},
 				"dotenv": {
 					"version": "5.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==",
 					"dev": true
 				},
 				"duplexer3": {
 					"version": "0.1.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
 					"dev": true
 				},
 				"duplexify": {
 					"version": "3.6.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
 					"dev": true,
 					"requires": {
 						"end-of-stream": "^1.0.0",
@@ -9410,7 +10261,8 @@
 					"dependencies": {
 						"readable-stream": {
 							"version": "2.3.6",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 							"dev": true,
 							"requires": {
 								"core-util-is": "~1.0.0",
@@ -9424,7 +10276,8 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 							"dev": true,
 							"requires": {
 								"safe-buffer": "~5.1.0"
@@ -9434,7 +10287,8 @@
 				},
 				"ecc-jsbn": {
 					"version": "0.1.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -9444,12 +10298,14 @@
 				},
 				"editor": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=",
 					"dev": true
 				},
 				"encoding": {
 					"version": "0.1.12",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
 					"dev": true,
 					"requires": {
 						"iconv-lite": "~0.4.13"
@@ -9457,7 +10313,8 @@
 				},
 				"end-of-stream": {
 					"version": "1.4.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
 					"dev": true,
 					"requires": {
 						"once": "^1.4.0"
@@ -9465,17 +10322,20 @@
 				},
 				"env-paths": {
 					"version": "2.2.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
 					"dev": true
 				},
 				"err-code": {
 					"version": "1.1.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
 					"dev": true
 				},
 				"errno": {
 					"version": "0.1.7",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
 					"dev": true,
 					"requires": {
 						"prr": "~1.0.1"
@@ -9483,7 +10343,8 @@
 				},
 				"es-abstract": {
 					"version": "1.12.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
 					"dev": true,
 					"requires": {
 						"es-to-primitive": "^1.1.1",
@@ -9495,7 +10356,8 @@
 				},
 				"es-to-primitive": {
 					"version": "1.2.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
 					"dev": true,
 					"requires": {
 						"is-callable": "^1.1.4",
@@ -9505,12 +10367,14 @@
 				},
 				"es6-promise": {
 					"version": "4.2.8",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
 					"dev": true
 				},
 				"es6-promisify": {
 					"version": "5.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
 					"dev": true,
 					"requires": {
 						"es6-promise": "^4.0.3"
@@ -9518,12 +10382,14 @@
 				},
 				"escape-string-regexp": {
 					"version": "1.0.5",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
 					"dev": true
 				},
 				"execa": {
 					"version": "0.7.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 					"dev": true,
 					"requires": {
 						"cross-spawn": "^5.0.1",
@@ -9537,44 +10403,52 @@
 					"dependencies": {
 						"get-stream": {
 							"version": "3.0.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
 							"dev": true
 						}
 					}
 				},
 				"extend": {
 					"version": "3.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
 					"dev": true
 				},
 				"extsprintf": {
 					"version": "1.3.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
 					"dev": true
 				},
 				"fast-deep-equal": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
 					"dev": true
 				},
 				"fast-json-stable-stringify": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
 					"dev": true
 				},
 				"figgy-pudding": {
 					"version": "3.5.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
 					"dev": true
 				},
 				"find-npm-prefix": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-KEftzJ+H90x6pcKtdXZEPsQse8/y/UnvzRKrOSQFprnrGaFuJ62fVkP34Iu2IYuMvyauCyoLTNkJZgrrGA2wkA==",
 					"dev": true
 				},
 				"find-up": {
 					"version": "2.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"dev": true,
 					"requires": {
 						"locate-path": "^2.0.0"
@@ -9582,7 +10456,8 @@
 				},
 				"flush-write-stream": {
 					"version": "1.0.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
 					"dev": true,
 					"requires": {
 						"inherits": "^2.0.1",
@@ -9591,7 +10466,8 @@
 					"dependencies": {
 						"readable-stream": {
 							"version": "2.3.6",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 							"dev": true,
 							"requires": {
 								"core-util-is": "~1.0.0",
@@ -9605,7 +10481,8 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 							"dev": true,
 							"requires": {
 								"safe-buffer": "~5.1.0"
@@ -9615,12 +10492,14 @@
 				},
 				"forever-agent": {
 					"version": "0.6.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
 					"dev": true
 				},
 				"form-data": {
 					"version": "2.3.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
 					"dev": true,
 					"requires": {
 						"asynckit": "^0.4.0",
@@ -9630,7 +10509,8 @@
 				},
 				"from2": {
 					"version": "2.3.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
 					"dev": true,
 					"requires": {
 						"inherits": "^2.0.1",
@@ -9639,7 +10519,8 @@
 					"dependencies": {
 						"readable-stream": {
 							"version": "2.3.6",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 							"dev": true,
 							"requires": {
 								"core-util-is": "~1.0.0",
@@ -9653,7 +10534,8 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 							"dev": true,
 							"requires": {
 								"safe-buffer": "~5.1.0"
@@ -9663,7 +10545,8 @@
 				},
 				"fs-minipass": {
 					"version": "1.2.7",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
 					"dev": true,
 					"requires": {
 						"minipass": "^2.6.0"
@@ -9671,7 +10554,8 @@
 					"dependencies": {
 						"minipass": {
 							"version": "2.9.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
 							"dev": true,
 							"requires": {
 								"safe-buffer": "^5.1.2",
@@ -9682,7 +10566,8 @@
 				},
 				"fs-vacuum": {
 					"version": "1.2.10",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
 					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
@@ -9692,7 +10577,8 @@
 				},
 				"fs-write-stream-atomic": {
 					"version": "1.0.10",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
 					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
@@ -9703,12 +10589,14 @@
 					"dependencies": {
 						"iferr": {
 							"version": "0.1.5",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
 							"dev": true
 						},
 						"readable-stream": {
 							"version": "2.3.6",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 							"dev": true,
 							"requires": {
 								"core-util-is": "~1.0.0",
@@ -9722,7 +10610,8 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 							"dev": true,
 							"requires": {
 								"safe-buffer": "~5.1.0"
@@ -9732,17 +10621,20 @@
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 					"dev": true
 				},
 				"function-bind": {
 					"version": "1.1.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
 					"dev": true
 				},
 				"gauge": {
 					"version": "2.7.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 					"dev": true,
 					"requires": {
 						"aproba": "^1.0.3",
@@ -9757,12 +10649,14 @@
 					"dependencies": {
 						"aproba": {
 							"version": "1.2.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
 							"dev": true
 						},
 						"string-width": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 							"dev": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
@@ -9774,12 +10668,14 @@
 				},
 				"genfun": {
 					"version": "5.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA==",
 					"dev": true
 				},
 				"gentle-fs": {
 					"version": "2.3.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-3k2CgAmPxuz7S6nKK+AqFE2AdM1QuwqKLPKzIET3VRwK++3q96MsNFobScDjlCrq97ZJ8y5R725MOlm6ffUCjg==",
 					"dev": true,
 					"requires": {
 						"aproba": "^1.1.2",
@@ -9797,24 +10693,28 @@
 					"dependencies": {
 						"aproba": {
 							"version": "1.2.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
 							"dev": true
 						},
 						"iferr": {
 							"version": "0.1.5",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
 							"dev": true
 						}
 					}
 				},
 				"get-caller-file": {
 					"version": "1.0.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
 					"dev": true
 				},
 				"get-stream": {
 					"version": "4.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
 					"dev": true,
 					"requires": {
 						"pump": "^3.0.0"
@@ -9822,7 +10722,8 @@
 				},
 				"getpass": {
 					"version": "0.1.7",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 					"dev": true,
 					"requires": {
 						"assert-plus": "^1.0.0"
@@ -9830,7 +10731,8 @@
 				},
 				"glob": {
 					"version": "7.1.6",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
 					"dev": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
@@ -9843,7 +10745,8 @@
 				},
 				"global-dirs": {
 					"version": "0.1.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
 					"dev": true,
 					"requires": {
 						"ini": "^1.3.4"
@@ -9851,7 +10754,8 @@
 				},
 				"got": {
 					"version": "6.7.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
 					"dev": true,
 					"requires": {
 						"create-error-class": "^3.0.0",
@@ -9869,24 +10773,28 @@
 					"dependencies": {
 						"get-stream": {
 							"version": "3.0.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
 							"dev": true
 						}
 					}
 				},
 				"graceful-fs": {
 					"version": "4.2.4",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
 					"dev": true
 				},
 				"har-schema": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
 					"dev": true
 				},
 				"har-validator": {
 					"version": "5.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
 					"dev": true,
 					"requires": {
 						"ajv": "^5.3.0",
@@ -9895,7 +10803,8 @@
 				},
 				"has": {
 					"version": "1.0.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
 					"dev": true,
 					"requires": {
 						"function-bind": "^1.1.1"
@@ -9903,32 +10812,38 @@
 				},
 				"has-flag": {
 					"version": "3.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 					"dev": true
 				},
 				"has-symbols": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
 					"dev": true
 				},
 				"has-unicode": {
 					"version": "2.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
 					"dev": true
 				},
 				"hosted-git-info": {
 					"version": "2.8.8",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
 					"dev": true
 				},
 				"http-cache-semantics": {
 					"version": "3.8.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
 					"dev": true
 				},
 				"http-proxy-agent": {
 					"version": "2.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
 					"dev": true,
 					"requires": {
 						"agent-base": "4",
@@ -9937,7 +10852,8 @@
 				},
 				"http-signature": {
 					"version": "1.2.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 					"dev": true,
 					"requires": {
 						"assert-plus": "^1.0.0",
@@ -9947,7 +10863,8 @@
 				},
 				"https-proxy-agent": {
 					"version": "2.2.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
 					"dev": true,
 					"requires": {
 						"agent-base": "^4.3.0",
@@ -9956,7 +10873,8 @@
 				},
 				"humanize-ms": {
 					"version": "1.2.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
 					"dev": true,
 					"requires": {
 						"ms": "^2.0.0"
@@ -9964,7 +10882,8 @@
 				},
 				"iconv-lite": {
 					"version": "0.4.23",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
 					"dev": true,
 					"requires": {
 						"safer-buffer": ">= 2.1.2 < 3"
@@ -9972,12 +10891,14 @@
 				},
 				"iferr": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-9AfeLfji44r5TKInjhz3W9DyZI1zR1JAf2hVBMGhddAKPqBsupb89jGfbCTHIGZd6fGZl9WlHdn4AObygyMKwg==",
 					"dev": true
 				},
 				"ignore-walk": {
 					"version": "3.0.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
 					"dev": true,
 					"requires": {
 						"minimatch": "^3.0.4"
@@ -9985,22 +10906,26 @@
 				},
 				"import-lazy": {
 					"version": "2.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
 					"dev": true
 				},
 				"imurmurhash": {
 					"version": "0.1.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
 					"dev": true
 				},
 				"infer-owner": {
 					"version": "1.0.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
 					"dev": true
 				},
 				"inflight": {
 					"version": "1.0.6",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 					"dev": true,
 					"requires": {
 						"once": "^1.3.0",
@@ -10009,17 +10934,20 @@
 				},
 				"inherits": {
 					"version": "2.0.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 					"dev": true
 				},
 				"ini": {
 					"version": "1.3.5",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
 					"dev": true
 				},
 				"init-package-json": {
 					"version": "1.10.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-zKSiXKhQveNteyhcj1CoOP8tqp1QuxPIPBl8Bid99DGLFqA1p87M6lNgfjJHSBoWJJlidGOv5rWjyYKEB3g2Jw==",
 					"dev": true,
 					"requires": {
 						"glob": "^7.1.1",
@@ -10034,27 +10962,32 @@
 				},
 				"invert-kv": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
 					"dev": true
 				},
 				"ip": {
 					"version": "1.1.5",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
 					"dev": true
 				},
 				"ip-regex": {
 					"version": "2.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
 					"dev": true
 				},
 				"is-callable": {
 					"version": "1.1.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
 					"dev": true
 				},
 				"is-ci": {
 					"version": "1.2.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
 					"dev": true,
 					"requires": {
 						"ci-info": "^1.5.0"
@@ -10062,14 +10995,16 @@
 					"dependencies": {
 						"ci-info": {
 							"version": "1.6.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
 							"dev": true
 						}
 					}
 				},
 				"is-cidr": {
 					"version": "3.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-8Xnnbjsb0x462VoYiGlhEi+drY8SFwrHiSYuzc/CEwco55vkehTaxAyIjEdpi3EMvLPPJAJi9FlzP+h+03gp0Q==",
 					"dev": true,
 					"requires": {
 						"cidr-regex": "^2.0.10"
@@ -10077,12 +11012,14 @@
 				},
 				"is-date-object": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
 					"dev": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
@@ -10090,7 +11027,8 @@
 				},
 				"is-installed-globally": {
 					"version": "0.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
 					"dev": true,
 					"requires": {
 						"global-dirs": "^0.1.0",
@@ -10099,17 +11037,20 @@
 				},
 				"is-npm": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
 					"dev": true
 				},
 				"is-obj": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
 					"dev": true
 				},
 				"is-path-inside": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
 					"dev": true,
 					"requires": {
 						"path-is-inside": "^1.0.1"
@@ -10117,12 +11058,14 @@
 				},
 				"is-redirect": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
 					"dev": true
 				},
 				"is-regex": {
 					"version": "1.0.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
 					"dev": true,
 					"requires": {
 						"has": "^1.0.1"
@@ -10130,17 +11073,20 @@
 				},
 				"is-retry-allowed": {
 					"version": "1.2.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
 					"dev": true
 				},
 				"is-stream": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
 					"dev": true
 				},
 				"is-symbol": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
 					"dev": true,
 					"requires": {
 						"has-symbols": "^1.0.0"
@@ -10148,58 +11094,69 @@
 				},
 				"is-typedarray": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
 					"dev": true
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 					"dev": true
 				},
 				"isexe": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
 					"dev": true
 				},
 				"isstream": {
 					"version": "0.1.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
 					"dev": true
 				},
 				"jsbn": {
 					"version": "0.1.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
 					"dev": true,
 					"optional": true
 				},
 				"json-parse-better-errors": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
 					"dev": true
 				},
 				"json-schema": {
 					"version": "0.2.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
 					"dev": true
 				},
 				"json-schema-traverse": {
 					"version": "0.3.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
 					"dev": true
 				},
 				"json-stringify-safe": {
 					"version": "5.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
 					"dev": true
 				},
 				"jsonparse": {
 					"version": "1.3.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
 					"dev": true
 				},
 				"jsprim": {
 					"version": "1.4.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
 					"dev": true,
 					"requires": {
 						"assert-plus": "1.0.0",
@@ -10210,7 +11167,8 @@
 				},
 				"latest-version": {
 					"version": "3.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
 					"dev": true,
 					"requires": {
 						"package-json": "^4.0.0"
@@ -10218,12 +11176,14 @@
 				},
 				"lazy-property": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc=",
 					"dev": true
 				},
 				"lcid": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
 					"dev": true,
 					"requires": {
 						"invert-kv": "^2.0.0"
@@ -10231,7 +11191,8 @@
 				},
 				"libcipm": {
 					"version": "4.0.7",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-fTq33otU3PNXxxCTCYCYe7V96o59v/o7bvtspmbORXpgFk+wcWrGf5x6tBgui5gCed/45/wtPomBsZBYm5KbIw==",
 					"dev": true,
 					"requires": {
 						"bin-links": "^1.1.2",
@@ -10253,7 +11214,8 @@
 				},
 				"libnpm": {
 					"version": "3.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-d7jU5ZcMiTfBqTUJVZ3xid44fE5ERBm9vBnmhp2ECD2Ls+FNXWxHSkO7gtvrnbLO78gwPdNPz1HpsF3W4rjkBQ==",
 					"dev": true,
 					"requires": {
 						"bin-links": "^1.1.2",
@@ -10280,7 +11242,8 @@
 				},
 				"libnpmaccess": {
 					"version": "3.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-01512AK7MqByrI2mfC7h5j8N9V4I7MHJuk9buo8Gv+5QgThpOgpjB7sQBDDkeZqRteFb1QM/6YNdHfG7cDvfAQ==",
 					"dev": true,
 					"requires": {
 						"aproba": "^2.0.0",
@@ -10291,7 +11254,8 @@
 				},
 				"libnpmconfig": {
 					"version": "1.2.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-9esX8rTQAHqarx6qeZqmGQKBNZR5OIbl/Ayr0qQDy3oXja2iFVQQI81R6GZ2a02bSNZ9p3YOGX1O6HHCb1X7kA==",
 					"dev": true,
 					"requires": {
 						"figgy-pudding": "^3.5.1",
@@ -10301,7 +11265,8 @@
 					"dependencies": {
 						"find-up": {
 							"version": "3.0.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
 							"dev": true,
 							"requires": {
 								"locate-path": "^3.0.0"
@@ -10309,7 +11274,8 @@
 						},
 						"locate-path": {
 							"version": "3.0.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
 							"dev": true,
 							"requires": {
 								"p-locate": "^3.0.0",
@@ -10318,7 +11284,8 @@
 						},
 						"p-limit": {
 							"version": "2.2.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
 							"dev": true,
 							"requires": {
 								"p-try": "^2.0.0"
@@ -10326,7 +11293,8 @@
 						},
 						"p-locate": {
 							"version": "3.0.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
 							"dev": true,
 							"requires": {
 								"p-limit": "^2.0.0"
@@ -10334,14 +11302,16 @@
 						},
 						"p-try": {
 							"version": "2.2.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 							"dev": true
 						}
 					}
 				},
 				"libnpmhook": {
 					"version": "5.0.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-UdNLMuefVZra/wbnBXECZPefHMGsVDTq5zaM/LgKNE9Keyl5YXQTnGAzEo+nFOpdRqTWI9LYi4ApqF9uVCCtuA==",
 					"dev": true,
 					"requires": {
 						"aproba": "^2.0.0",
@@ -10352,7 +11322,8 @@
 				},
 				"libnpmorg": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-0sRUXLh+PLBgZmARvthhYXQAWn0fOsa6T5l3JSe2n9vKG/lCVK4nuG7pDsa7uMq+uTt2epdPK+a2g6btcY11Ww==",
 					"dev": true,
 					"requires": {
 						"aproba": "^2.0.0",
@@ -10363,7 +11334,8 @@
 				},
 				"libnpmpublish": {
 					"version": "1.1.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-2yIwaXrhTTcF7bkJKIKmaCV9wZOALf/gsTDxVSu/Gu/6wiG3fA8ce8YKstiWKTxSFNC0R7isPUb6tXTVFZHt2g==",
 					"dev": true,
 					"requires": {
 						"aproba": "^2.0.0",
@@ -10379,7 +11351,8 @@
 				},
 				"libnpmsearch": {
 					"version": "2.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-VTBbV55Q6fRzTdzziYCr64+f8AopQ1YZ+BdPOv16UegIEaE8C0Kch01wo4s3kRTFV64P121WZJwgmBwrq68zYg==",
 					"dev": true,
 					"requires": {
 						"figgy-pudding": "^3.5.1",
@@ -10389,7 +11362,8 @@
 				},
 				"libnpmteam": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-p420vM28Us04NAcg1rzgGW63LMM6rwe+6rtZpfDxCcXxM0zUTLl7nPFEnRF3JfFBF5skF/yuZDUthTsHgde8QA==",
 					"dev": true,
 					"requires": {
 						"aproba": "^2.0.0",
@@ -10400,7 +11374,8 @@
 				},
 				"libnpx": {
 					"version": "10.2.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-ujaYToga1SAX5r7FU5ShMFi88CWpY75meNZtr6RtEyv4l2ZK3+Wgvxq2IqlwWBiDZOqhumdeiocPS1aKrCMe3A==",
 					"dev": true,
 					"requires": {
 						"dotenv": "^5.0.1",
@@ -10415,7 +11390,8 @@
 				},
 				"locate-path": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 					"dev": true,
 					"requires": {
 						"p-locate": "^2.0.0",
@@ -10424,7 +11400,8 @@
 				},
 				"lock-verify": {
 					"version": "2.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-vcLpxnGvrqisKvLQ2C2v0/u7LVly17ak2YSgoK4PrdsYBXQIax19vhKiLfvKNFx7FRrpTnitrpzF/uuCMuorIg==",
 					"dev": true,
 					"requires": {
 						"npm-package-arg": "^6.1.0",
@@ -10433,7 +11410,8 @@
 				},
 				"lockfile": {
 					"version": "1.0.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
 					"dev": true,
 					"requires": {
 						"signal-exit": "^3.0.2"
@@ -10441,12 +11419,14 @@
 				},
 				"lodash._baseindexof": {
 					"version": "3.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
 					"dev": true
 				},
 				"lodash._baseuniq": {
 					"version": "4.6.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
 					"dev": true,
 					"requires": {
 						"lodash._createset": "~4.0.0",
@@ -10455,17 +11435,20 @@
 				},
 				"lodash._bindcallback": {
 					"version": "3.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
 					"dev": true
 				},
 				"lodash._cacheindexof": {
 					"version": "3.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
 					"dev": true
 				},
 				"lodash._createcache": {
 					"version": "3.1.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
 					"dev": true,
 					"requires": {
 						"lodash._getnative": "^3.0.0"
@@ -10473,52 +11456,62 @@
 				},
 				"lodash._createset": {
 					"version": "4.0.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=",
 					"dev": true
 				},
 				"lodash._getnative": {
 					"version": "3.9.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
 					"dev": true
 				},
 				"lodash._root": {
 					"version": "3.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
 					"dev": true
 				},
 				"lodash.clonedeep": {
 					"version": "4.5.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
 					"dev": true
 				},
 				"lodash.restparam": {
 					"version": "3.6.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
 					"dev": true
 				},
 				"lodash.union": {
 					"version": "4.6.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
 					"dev": true
 				},
 				"lodash.uniq": {
 					"version": "4.5.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
 					"dev": true
 				},
 				"lodash.without": {
 					"version": "4.4.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=",
 					"dev": true
 				},
 				"lowercase-keys": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
 					"dev": true
 				},
 				"lru-cache": {
 					"version": "5.1.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
 					"dev": true,
 					"requires": {
 						"yallist": "^3.0.2"
@@ -10526,7 +11519,8 @@
 				},
 				"make-dir": {
 					"version": "1.3.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
 					"dev": true,
 					"requires": {
 						"pify": "^3.0.0"
@@ -10534,7 +11528,8 @@
 				},
 				"make-fetch-happen": {
 					"version": "5.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-07JHC0r1ykIoruKO8ifMXu+xEU8qOXDFETylktdug6vJDACnP+HKevOu3PXyNPzFyTSlz8vrBYlBO1JZRe8Cag==",
 					"dev": true,
 					"requires": {
 						"agentkeepalive": "^3.4.1",
@@ -10552,7 +11547,8 @@
 				},
 				"map-age-cleaner": {
 					"version": "0.1.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
 					"dev": true,
 					"requires": {
 						"p-defer": "^1.0.0"
@@ -10560,12 +11556,14 @@
 				},
 				"meant": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-UakVLFjKkbbUwNWJ2frVLnnAtbb7D7DsloxRd3s/gDpI8rdv8W5Hp3NaDb+POBI1fQdeussER6NB8vpcRURvlg==",
 					"dev": true
 				},
 				"mem": {
 					"version": "4.3.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
 					"dev": true,
 					"requires": {
 						"map-age-cleaner": "^0.1.1",
@@ -10575,19 +11573,22 @@
 					"dependencies": {
 						"mimic-fn": {
 							"version": "2.1.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
 							"dev": true
 						}
 					}
 				},
 				"mime-db": {
 					"version": "1.35.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg==",
 					"dev": true
 				},
 				"mime-types": {
 					"version": "2.1.19",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
 					"dev": true,
 					"requires": {
 						"mime-db": "~1.35.0"
@@ -10595,7 +11596,8 @@
 				},
 				"minimatch": {
 					"version": "3.0.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"dev": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
@@ -10603,7 +11605,8 @@
 				},
 				"minizlib": {
 					"version": "1.3.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
 					"dev": true,
 					"requires": {
 						"minipass": "^2.9.0"
@@ -10611,7 +11614,8 @@
 					"dependencies": {
 						"minipass": {
 							"version": "2.9.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
 							"dev": true,
 							"requires": {
 								"safe-buffer": "^5.1.2",
@@ -10622,7 +11626,8 @@
 				},
 				"mississippi": {
 					"version": "3.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
 					"dev": true,
 					"requires": {
 						"concat-stream": "^1.5.0",
@@ -10639,7 +11644,8 @@
 				},
 				"mkdirp": {
 					"version": "0.5.5",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+					"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
 					"dev": true,
 					"requires": {
 						"minimist": "^1.2.5"
@@ -10647,14 +11653,16 @@
 					"dependencies": {
 						"minimist": {
 							"version": "1.2.5",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
 							"dev": true
 						}
 					}
 				},
 				"move-concurrently": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
 					"dev": true,
 					"requires": {
 						"aproba": "^1.1.1",
@@ -10667,29 +11675,34 @@
 					"dependencies": {
 						"aproba": {
 							"version": "1.2.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
 							"dev": true
 						}
 					}
 				},
 				"ms": {
 					"version": "2.1.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
 					"dev": true
 				},
 				"mute-stream": {
 					"version": "0.0.7",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
 					"dev": true
 				},
 				"nice-try": {
 					"version": "1.0.5",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 					"dev": true
 				},
 				"node-fetch-npm": {
 					"version": "2.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
 					"dev": true,
 					"requires": {
 						"encoding": "^0.1.11",
@@ -10699,7 +11712,8 @@
 				},
 				"node-gyp": {
 					"version": "5.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-OUTryc5bt/P8zVgNUmC6xdXiDJxLMAW8cF5tLQOT9E5sOQj+UeQxnnPy74K3CLCa/SOjjBlbuzDLR8ANwA+wmw==",
 					"dev": true,
 					"requires": {
 						"env-paths": "^2.2.0",
@@ -10717,7 +11731,8 @@
 				},
 				"nopt": {
 					"version": "4.0.3",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+					"integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
 					"dev": true,
 					"requires": {
 						"abbrev": "1",
@@ -10726,7 +11741,8 @@
 				},
 				"normalize-package-data": {
 					"version": "2.5.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
 					"dev": true,
 					"requires": {
 						"hosted-git-info": "^2.1.4",
@@ -10737,7 +11753,8 @@
 					"dependencies": {
 						"resolve": {
 							"version": "1.10.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
 							"dev": true,
 							"requires": {
 								"path-parse": "^1.0.6"
@@ -10747,7 +11764,8 @@
 				},
 				"npm-audit-report": {
 					"version": "1.3.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-abeqS5ONyXNaZJPGAf6TOUMNdSe1Y6cpc9MLBRn+CuUoYbfdca6AxOyXVlfIv9OgKX+cacblbG5w7A6ccwoTPw==",
 					"dev": true,
 					"requires": {
 						"cli-table3": "^0.5.0",
@@ -10756,7 +11774,8 @@
 				},
 				"npm-bundled": {
 					"version": "1.1.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
 					"dev": true,
 					"requires": {
 						"npm-normalize-package-bin": "^1.0.1"
@@ -10764,12 +11783,14 @@
 				},
 				"npm-cache-filename": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=",
 					"dev": true
 				},
 				"npm-install-checks": {
 					"version": "3.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-E4kzkyZDIWoin6uT5howP8VDvkM+E8IQDcHAycaAxMbwkqhIg5eEYALnXOl3Hq9MrkdQB/2/g1xwBINXdKSRkg==",
 					"dev": true,
 					"requires": {
 						"semver": "^2.3.0 || 3.x || 4 || 5"
@@ -10777,7 +11798,8 @@
 				},
 				"npm-lifecycle": {
 					"version": "3.1.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-tgs1PaucZwkxECGKhC/stbEgFyc3TGh2TJcg2CDr6jbvQRdteHNhmMeljRzpe4wgFAXQADoy1cSqqi7mtiAa5A==",
 					"dev": true,
 					"requires": {
 						"byline": "^5.0.0",
@@ -10792,17 +11814,20 @@
 				},
 				"npm-logical-tree": {
 					"version": "1.2.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-AJI/qxDB2PWI4LG1CYN579AY1vCiNyWfkiquCsJWqntRu/WwimVrC8yXeILBFHDwxfOejxewlmnvW9XXjMlYIg==",
 					"dev": true
 				},
 				"npm-normalize-package-bin": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
 					"dev": true
 				},
 				"npm-package-arg": {
 					"version": "6.1.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-qBpssaL3IOZWi5vEKUKW0cO7kzLeT+EQO9W8RsLOZf76KF9E/K9+wH0C7t06HXPpaH8WH5xF1MExLuCwbTqRUg==",
 					"dev": true,
 					"requires": {
 						"hosted-git-info": "^2.7.1",
@@ -10813,7 +11838,8 @@
 				},
 				"npm-packlist": {
 					"version": "1.4.8",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
 					"dev": true,
 					"requires": {
 						"ignore-walk": "^3.0.1",
@@ -10823,7 +11849,8 @@
 				},
 				"npm-pick-manifest": {
 					"version": "3.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-wNprTNg+X5nf+tDi+hbjdHhM4bX+mKqv6XmPh7B5eG+QY9VARfQPfCEH013H5GqfNj6ee8Ij2fg8yk0mzps1Vw==",
 					"dev": true,
 					"requires": {
 						"figgy-pudding": "^3.5.1",
@@ -10833,7 +11860,8 @@
 				},
 				"npm-profile": {
 					"version": "4.0.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-Ta8xq8TLMpqssF0H60BXS1A90iMoM6GeKwsmravJ6wYjWwSzcYBTdyWa3DZCYqPutacBMEm7cxiOkiIeCUAHDQ==",
 					"dev": true,
 					"requires": {
 						"aproba": "^1.1.2 || 2",
@@ -10843,7 +11871,8 @@
 				},
 				"npm-registry-fetch": {
 					"version": "4.0.4",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-4.0.4.tgz",
+					"integrity": "sha512-6jb34hX/iYNQebqWUHtU8YF6Cjb1H6ouTFPClYsyiW6lpFkljTpdeftm53rRojtja1rKAvKNIIiTS5Sjpw4wsA==",
 					"dev": true,
 					"requires": {
 						"JSONStream": "^1.3.4",
@@ -10857,14 +11886,16 @@
 					"dependencies": {
 						"safe-buffer": {
 							"version": "5.2.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
 							"dev": true
 						}
 					}
 				},
 				"npm-run-path": {
 					"version": "2.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 					"dev": true,
 					"requires": {
 						"path-key": "^2.0.0"
@@ -10872,12 +11903,14 @@
 				},
 				"npm-user-validate": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-jOyg9c6gTU6TUZ73LQVXp1Ei6VE=",
 					"dev": true
 				},
 				"npmlog": {
 					"version": "4.1.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 					"dev": true,
 					"requires": {
 						"are-we-there-yet": "~1.1.2",
@@ -10888,27 +11921,32 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 					"dev": true
 				},
 				"oauth-sign": {
 					"version": "0.9.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
 					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
 					"dev": true
 				},
 				"object-keys": {
 					"version": "1.0.12",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
 					"dev": true
 				},
 				"object.getownpropertydescriptors": {
 					"version": "2.0.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
 					"dev": true,
 					"requires": {
 						"define-properties": "^1.1.2",
@@ -10917,7 +11955,8 @@
 				},
 				"once": {
 					"version": "1.4.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 					"dev": true,
 					"requires": {
 						"wrappy": "1"
@@ -10925,17 +11964,20 @@
 				},
 				"opener": {
 					"version": "1.5.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==",
 					"dev": true
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 					"dev": true
 				},
 				"os-locale": {
 					"version": "3.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
 					"dev": true,
 					"requires": {
 						"execa": "^1.0.0",
@@ -10945,7 +11987,8 @@
 					"dependencies": {
 						"cross-spawn": {
 							"version": "6.0.5",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 							"dev": true,
 							"requires": {
 								"nice-try": "^1.0.4",
@@ -10957,7 +12000,8 @@
 						},
 						"execa": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
 							"dev": true,
 							"requires": {
 								"cross-spawn": "^6.0.0",
@@ -10973,12 +12017,14 @@
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 					"dev": true
 				},
 				"osenv": {
 					"version": "0.1.5",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
 					"dev": true,
 					"requires": {
 						"os-homedir": "^1.0.0",
@@ -10987,22 +12033,26 @@
 				},
 				"p-defer": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
 					"dev": true
 				},
 				"p-finally": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
 					"dev": true
 				},
 				"p-is-promise": {
 					"version": "2.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
 					"dev": true
 				},
 				"p-limit": {
 					"version": "1.2.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
 					"dev": true,
 					"requires": {
 						"p-try": "^1.0.0"
@@ -11010,7 +12060,8 @@
 				},
 				"p-locate": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 					"dev": true,
 					"requires": {
 						"p-limit": "^1.1.0"
@@ -11018,12 +12069,14 @@
 				},
 				"p-try": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
 					"dev": true
 				},
 				"package-json": {
 					"version": "4.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
 					"dev": true,
 					"requires": {
 						"got": "^6.7.1",
@@ -11034,7 +12087,8 @@
 				},
 				"pacote": {
 					"version": "9.5.12",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-BUIj/4kKbwWg4RtnBncXPJd15piFSVNpTzY0rysSr3VnMowTYgkGKcaHrbReepAkjTr8lH2CVWRi58Spg2CicQ==",
 					"dev": true,
 					"requires": {
 						"bluebird": "^3.5.3",
@@ -11071,7 +12125,8 @@
 					"dependencies": {
 						"minipass": {
 							"version": "2.9.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
 							"dev": true,
 							"requires": {
 								"safe-buffer": "^5.1.2",
@@ -11082,7 +12137,8 @@
 				},
 				"parallel-transform": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
 					"dev": true,
 					"requires": {
 						"cyclist": "~0.2.2",
@@ -11092,7 +12148,8 @@
 					"dependencies": {
 						"readable-stream": {
 							"version": "2.3.6",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 							"dev": true,
 							"requires": {
 								"core-util-is": "~1.0.0",
@@ -11106,7 +12163,8 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 							"dev": true,
 							"requires": {
 								"safe-buffer": "~5.1.0"
@@ -11116,57 +12174,68 @@
 				},
 				"path-exists": {
 					"version": "3.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
 					"dev": true
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 					"dev": true
 				},
 				"path-is-inside": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
 					"dev": true
 				},
 				"path-key": {
 					"version": "2.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
 					"dev": true
 				},
 				"path-parse": {
 					"version": "1.0.6",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
 					"dev": true
 				},
 				"performance-now": {
 					"version": "2.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
 					"dev": true
 				},
 				"pify": {
 					"version": "3.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
 					"dev": true
 				},
 				"prepend-http": {
 					"version": "1.0.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
 					"dev": true
 				},
 				"process-nextick-args": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
 					"dev": true
 				},
 				"promise-inflight": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
 					"dev": true
 				},
 				"promise-retry": {
 					"version": "1.1.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
 					"dev": true,
 					"requires": {
 						"err-code": "^1.0.0",
@@ -11175,14 +12244,16 @@
 					"dependencies": {
 						"retry": {
 							"version": "0.10.1",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
 							"dev": true
 						}
 					}
 				},
 				"promzard": {
 					"version": "0.3.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
 					"dev": true,
 					"requires": {
 						"read": "1"
@@ -11190,12 +12261,14 @@
 				},
 				"proto-list": {
 					"version": "1.2.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
 					"dev": true
 				},
 				"protoduck": {
 					"version": "5.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-WxoCeDCoCBY55BMvj4cAEjdVUFGRWed9ZxPlqTKYyw1nDDTQ4pqmnIMAGfJlg7Dx35uB/M+PHJPTmGOvaCaPTg==",
 					"dev": true,
 					"requires": {
 						"genfun": "^5.0.0"
@@ -11203,22 +12276,26 @@
 				},
 				"prr": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
 					"dev": true
 				},
 				"pseudomap": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
 					"dev": true
 				},
 				"psl": {
 					"version": "1.1.29",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
 					"dev": true
 				},
 				"pump": {
 					"version": "3.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
 					"dev": true,
 					"requires": {
 						"end-of-stream": "^1.1.0",
@@ -11227,7 +12304,8 @@
 				},
 				"pumpify": {
 					"version": "1.5.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
 					"dev": true,
 					"requires": {
 						"duplexify": "^3.6.0",
@@ -11237,7 +12315,8 @@
 					"dependencies": {
 						"pump": {
 							"version": "2.0.1",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
 							"dev": true,
 							"requires": {
 								"end-of-stream": "^1.1.0",
@@ -11248,22 +12327,26 @@
 				},
 				"punycode": {
 					"version": "1.4.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
 					"dev": true
 				},
 				"qrcode-terminal": {
 					"version": "0.12.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
 					"dev": true
 				},
 				"qs": {
 					"version": "6.5.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
 					"dev": true
 				},
 				"query-string": {
 					"version": "6.8.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-J3Qi8XZJXh93t2FiKyd/7Ec6GNifsjKXUsVFkSBj/kjLsDylWhnCz4NT1bkPcKotttPW+QbKGqqPH8OoI2pdqw==",
 					"dev": true,
 					"requires": {
 						"decode-uri-component": "^0.2.0",
@@ -11273,12 +12356,14 @@
 				},
 				"qw": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-77/cdA+a0FQwRCassYNBLMi5ltQ=",
 					"dev": true
 				},
 				"rc": {
 					"version": "1.2.8",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
 					"dev": true,
 					"requires": {
 						"deep-extend": "^0.6.0",
@@ -11289,14 +12374,16 @@
 					"dependencies": {
 						"minimist": {
 							"version": "1.2.5",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
 							"dev": true
 						}
 					}
 				},
 				"read": {
 					"version": "1.0.7",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
 					"dev": true,
 					"requires": {
 						"mute-stream": "~0.0.4"
@@ -11304,7 +12391,8 @@
 				},
 				"read-cmd-shim": {
 					"version": "1.0.5",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-v5yCqQ/7okKoZZkBQUAfTsQ3sVJtXdNfbPnI5cceppoxEVLYA3k+VtV2omkeo8MS94JCy4fSiUwlRBAwCVRPUA==",
 					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2"
@@ -11312,7 +12400,8 @@
 				},
 				"read-installed": {
 					"version": "4.0.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
 					"dev": true,
 					"requires": {
 						"debuglog": "^1.0.1",
@@ -11326,7 +12415,8 @@
 				},
 				"read-package-json": {
 					"version": "2.1.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-dAiqGtVc/q5doFz6096CcnXhpYk0ZN8dEKVkGLU0CsASt8SrgF6SF7OTKAYubfvFhWaqofl+Y8HK19GR8jwW+A==",
 					"dev": true,
 					"requires": {
 						"glob": "^7.1.1",
@@ -11338,7 +12428,8 @@
 				},
 				"read-package-tree": {
 					"version": "5.3.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-mLUDsD5JVtlZxjSlPPx1RETkNjjvQYuweKwNVt1Sn8kP5Jh44pvYuUHCp6xSVDZWbNxVxG5lyZJ921aJH61sTw==",
 					"dev": true,
 					"requires": {
 						"read-package-json": "^2.0.0",
@@ -11348,7 +12439,8 @@
 				},
 				"readable-stream": {
 					"version": "3.6.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
 					"dev": true,
 					"requires": {
 						"inherits": "^2.0.3",
@@ -11358,7 +12450,8 @@
 				},
 				"readdir-scoped-modules": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
 					"dev": true,
 					"requires": {
 						"debuglog": "^1.0.1",
@@ -11369,7 +12462,8 @@
 				},
 				"registry-auth-token": {
 					"version": "3.4.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
 					"dev": true,
 					"requires": {
 						"rc": "^1.1.6",
@@ -11378,7 +12472,8 @@
 				},
 				"registry-url": {
 					"version": "3.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
 					"dev": true,
 					"requires": {
 						"rc": "^1.0.1"
@@ -11386,7 +12481,8 @@
 				},
 				"request": {
 					"version": "2.88.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
 					"dev": true,
 					"requires": {
 						"aws-sign2": "~0.7.0",
@@ -11413,27 +12509,32 @@
 				},
 				"require-directory": {
 					"version": "2.1.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
 					"dev": true
 				},
 				"require-main-filename": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
 					"dev": true
 				},
 				"resolve-from": {
 					"version": "4.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
 					"dev": true
 				},
 				"retry": {
 					"version": "0.12.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
 					"dev": true
 				},
 				"rimraf": {
 					"version": "2.7.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
 					"dev": true,
 					"requires": {
 						"glob": "^7.1.3"
@@ -11441,7 +12542,8 @@
 				},
 				"run-queue": {
 					"version": "1.0.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
 					"dev": true,
 					"requires": {
 						"aproba": "^1.1.1"
@@ -11449,29 +12551,34 @@
 					"dependencies": {
 						"aproba": {
 							"version": "1.2.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
 							"dev": true
 						}
 					}
 				},
 				"safe-buffer": {
 					"version": "5.1.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 					"dev": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 					"dev": true
 				},
 				"semver": {
 					"version": "5.7.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 					"dev": true
 				},
 				"semver-diff": {
 					"version": "2.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
 					"dev": true,
 					"requires": {
 						"semver": "^5.0.3"
@@ -11479,12 +12586,14 @@
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 					"dev": true
 				},
 				"sha": {
 					"version": "3.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-DOYnM37cNsLNSGIG/zZWch5CKIRNoLdYUQTQlcgkRkoYIUwDYjqDyye16YcDZg/OPdcbUgTKMjc4SY6TB7ZAPw==",
 					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2"
@@ -11492,7 +12601,8 @@
 				},
 				"shebang-command": {
 					"version": "1.2.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 					"dev": true,
 					"requires": {
 						"shebang-regex": "^1.0.0"
@@ -11500,27 +12610,32 @@
 				},
 				"shebang-regex": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
 					"dev": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 					"dev": true
 				},
 				"slide": {
 					"version": "1.1.6",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
 					"dev": true
 				},
 				"smart-buffer": {
 					"version": "4.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==",
 					"dev": true
 				},
 				"socks": {
 					"version": "2.3.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-o5t52PCNtVdiOvzMry7wU4aOqYWL0PeCXRWBEiJow4/i/wr+wpsJQ9awEu1EonLIqsfGd5qSgDdxEOvCdmBEpA==",
 					"dev": true,
 					"requires": {
 						"ip": "1.1.5",
@@ -11529,7 +12644,8 @@
 				},
 				"socks-proxy-agent": {
 					"version": "4.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
 					"dev": true,
 					"requires": {
 						"agent-base": "~4.2.1",
@@ -11538,7 +12654,8 @@
 					"dependencies": {
 						"agent-base": {
 							"version": "4.2.1",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
 							"dev": true,
 							"requires": {
 								"es6-promisify": "^5.0.0"
@@ -11548,12 +12665,14 @@
 				},
 				"sorted-object": {
 					"version": "2.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw=",
 					"dev": true
 				},
 				"sorted-union-stream": {
 					"version": "2.1.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=",
 					"dev": true,
 					"requires": {
 						"from2": "^1.3.0",
@@ -11562,7 +12681,8 @@
 					"dependencies": {
 						"from2": {
 							"version": "1.3.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=",
 							"dev": true,
 							"requires": {
 								"inherits": "~2.0.1",
@@ -11571,12 +12691,14 @@
 						},
 						"isarray": {
 							"version": "0.0.1",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
 							"dev": true
 						},
 						"readable-stream": {
 							"version": "1.1.14",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
 							"dev": true,
 							"requires": {
 								"core-util-is": "~1.0.0",
@@ -11587,14 +12709,16 @@
 						},
 						"string_decoder": {
 							"version": "0.10.31",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
 							"dev": true
 						}
 					}
 				},
 				"spdx-correct": {
 					"version": "3.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
 					"dev": true,
 					"requires": {
 						"spdx-expression-parse": "^3.0.0",
@@ -11603,12 +12727,14 @@
 				},
 				"spdx-exceptions": {
 					"version": "2.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
 					"dev": true
 				},
 				"spdx-expression-parse": {
 					"version": "3.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
 					"dev": true,
 					"requires": {
 						"spdx-exceptions": "^2.1.0",
@@ -11617,17 +12743,20 @@
 				},
 				"spdx-license-ids": {
 					"version": "3.0.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
 					"dev": true
 				},
 				"split-on-first": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
 					"dev": true
 				},
 				"sshpk": {
 					"version": "1.14.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
 					"dev": true,
 					"requires": {
 						"asn1": "~0.2.3",
@@ -11643,7 +12772,8 @@
 				},
 				"ssri": {
 					"version": "6.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
 					"dev": true,
 					"requires": {
 						"figgy-pudding": "^3.5.1"
@@ -11651,7 +12781,8 @@
 				},
 				"stream-each": {
 					"version": "1.2.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
 					"dev": true,
 					"requires": {
 						"end-of-stream": "^1.1.0",
@@ -11660,7 +12791,8 @@
 				},
 				"stream-iterate": {
 					"version": "1.2.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=",
 					"dev": true,
 					"requires": {
 						"readable-stream": "^2.1.5",
@@ -11669,7 +12801,8 @@
 					"dependencies": {
 						"readable-stream": {
 							"version": "2.3.6",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 							"dev": true,
 							"requires": {
 								"core-util-is": "~1.0.0",
@@ -11683,7 +12816,8 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 							"dev": true,
 							"requires": {
 								"safe-buffer": "~5.1.0"
@@ -11693,17 +12827,20 @@
 				},
 				"stream-shift": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
 					"dev": true
 				},
 				"strict-uri-encode": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
 					"dev": true
 				},
 				"string-width": {
 					"version": "2.1.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "^2.0.0",
@@ -11712,17 +12849,20 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "3.0.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
 							"dev": true
 						},
 						"is-fullwidth-code-point": {
 							"version": "2.0.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
 							"dev": true
 						},
 						"strip-ansi": {
 							"version": "4.0.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 							"dev": true,
 							"requires": {
 								"ansi-regex": "^3.0.0"
@@ -11732,7 +12872,8 @@
 				},
 				"string_decoder": {
 					"version": "1.3.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
 					"dev": true,
 					"requires": {
 						"safe-buffer": "~5.2.0"
@@ -11740,19 +12881,22 @@
 					"dependencies": {
 						"safe-buffer": {
 							"version": "5.2.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
 							"dev": true
 						}
 					}
 				},
 				"stringify-package": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg==",
 					"dev": true
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
@@ -11760,17 +12904,20 @@
 				},
 				"strip-eof": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
 					"dev": true
 				},
 				"strip-json-comments": {
 					"version": "2.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 					"dev": true
 				},
 				"supports-color": {
 					"version": "5.4.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
@@ -11778,7 +12925,8 @@
 				},
 				"tar": {
 					"version": "4.4.13",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
 					"dev": true,
 					"requires": {
 						"chownr": "^1.1.1",
@@ -11792,7 +12940,8 @@
 					"dependencies": {
 						"minipass": {
 							"version": "2.9.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
 							"dev": true,
 							"requires": {
 								"safe-buffer": "^5.1.2",
@@ -11803,7 +12952,8 @@
 				},
 				"term-size": {
 					"version": "1.2.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
 					"dev": true,
 					"requires": {
 						"execa": "^0.7.0"
@@ -11811,17 +12961,20 @@
 				},
 				"text-table": {
 					"version": "0.2.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
 					"dev": true
 				},
 				"through": {
 					"version": "2.3.8",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
 					"dev": true
 				},
 				"through2": {
 					"version": "2.0.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
 					"dev": true,
 					"requires": {
 						"readable-stream": "^2.1.5",
@@ -11830,7 +12983,8 @@
 					"dependencies": {
 						"readable-stream": {
 							"version": "2.3.6",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 							"dev": true,
 							"requires": {
 								"core-util-is": "~1.0.0",
@@ -11844,7 +12998,8 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 							"dev": true,
 							"requires": {
 								"safe-buffer": "~5.1.0"
@@ -11854,17 +13009,20 @@
 				},
 				"timed-out": {
 					"version": "4.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
 					"dev": true
 				},
 				"tiny-relative-date": {
 					"version": "1.3.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-MOQHpzllWxDCHHaDno30hhLfbouoYlOI8YlMNtvKe1zXbjEVhbcEovQxvZrPvtiYW630GQDoMMarCnjfyfHA+A==",
 					"dev": true
 				},
 				"tough-cookie": {
 					"version": "2.4.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
 					"dev": true,
 					"requires": {
 						"psl": "^1.1.24",
@@ -11873,7 +13031,8 @@
 				},
 				"tunnel-agent": {
 					"version": "0.6.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 					"dev": true,
 					"requires": {
 						"safe-buffer": "^5.0.1"
@@ -11881,28 +13040,33 @@
 				},
 				"tweetnacl": {
 					"version": "0.14.5",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
 					"dev": true,
 					"optional": true
 				},
 				"typedarray": {
 					"version": "0.0.6",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
 					"dev": true
 				},
 				"uid-number": {
 					"version": "0.0.6",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
 					"dev": true
 				},
 				"umask": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
 					"dev": true
 				},
 				"unique-filename": {
 					"version": "1.1.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
 					"dev": true,
 					"requires": {
 						"unique-slug": "^2.0.0"
@@ -11910,7 +13074,8 @@
 				},
 				"unique-slug": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
 					"dev": true,
 					"requires": {
 						"imurmurhash": "^0.1.4"
@@ -11918,7 +13083,8 @@
 				},
 				"unique-string": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
 					"dev": true,
 					"requires": {
 						"crypto-random-string": "^1.0.0"
@@ -11926,17 +13092,20 @@
 				},
 				"unpipe": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
 					"dev": true
 				},
 				"unzip-response": {
 					"version": "2.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
 					"dev": true
 				},
 				"update-notifier": {
 					"version": "2.5.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
 					"dev": true,
 					"requires": {
 						"boxen": "^1.2.1",
@@ -11953,7 +13122,8 @@
 				},
 				"url-parse-lax": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
 					"dev": true,
 					"requires": {
 						"prepend-http": "^1.0.1"
@@ -11961,17 +13131,20 @@
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 					"dev": true
 				},
 				"util-extend": {
 					"version": "1.0.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
 					"dev": true
 				},
 				"util-promisify": {
 					"version": "2.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-PCI2R2xNMsX/PEcAKt18E7moKlM=",
 					"dev": true,
 					"requires": {
 						"object.getownpropertydescriptors": "^2.0.3"
@@ -11979,12 +13152,14 @@
 				},
 				"uuid": {
 					"version": "3.3.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
 					"dev": true
 				},
 				"validate-npm-package-license": {
 					"version": "3.0.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
 					"dev": true,
 					"requires": {
 						"spdx-correct": "^3.0.0",
@@ -11993,7 +13168,8 @@
 				},
 				"validate-npm-package-name": {
 					"version": "3.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
 					"dev": true,
 					"requires": {
 						"builtins": "^1.0.3"
@@ -12001,7 +13177,8 @@
 				},
 				"verror": {
 					"version": "1.10.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 					"dev": true,
 					"requires": {
 						"assert-plus": "^1.0.0",
@@ -12011,7 +13188,8 @@
 				},
 				"wcwidth": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
 					"dev": true,
 					"requires": {
 						"defaults": "^1.0.3"
@@ -12019,7 +13197,8 @@
 				},
 				"which": {
 					"version": "1.3.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
 					"dev": true,
 					"requires": {
 						"isexe": "^2.0.0"
@@ -12027,12 +13206,14 @@
 				},
 				"which-module": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
 					"dev": true
 				},
 				"wide-align": {
 					"version": "1.1.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
 					"dev": true,
 					"requires": {
 						"string-width": "^1.0.2"
@@ -12040,7 +13221,8 @@
 					"dependencies": {
 						"string-width": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 							"dev": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
@@ -12052,7 +13234,8 @@
 				},
 				"widest-line": {
 					"version": "2.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
 					"dev": true,
 					"requires": {
 						"string-width": "^2.1.1"
@@ -12060,7 +13243,8 @@
 				},
 				"worker-farm": {
 					"version": "1.7.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
 					"dev": true,
 					"requires": {
 						"errno": "~0.1.7"
@@ -12068,7 +13252,8 @@
 				},
 				"wrap-ansi": {
 					"version": "2.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 					"dev": true,
 					"requires": {
 						"string-width": "^1.0.1",
@@ -12077,7 +13262,8 @@
 					"dependencies": {
 						"string-width": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 							"dev": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
@@ -12089,12 +13275,14 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 					"dev": true
 				},
 				"write-file-atomic": {
 					"version": "2.4.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
 					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.11",
@@ -12104,27 +13292,32 @@
 				},
 				"xdg-basedir": {
 					"version": "3.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
 					"dev": true
 				},
 				"xtend": {
 					"version": "4.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
 					"dev": true
 				},
 				"y18n": {
 					"version": "4.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
 					"dev": true
 				},
 				"yallist": {
 					"version": "3.0.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
 					"dev": true
 				},
 				"yargs": {
 					"version": "11.1.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-PRU7gJrJaXv3q3yQZ/+/X6KBswZiaQ+zOmdprZcouPYtQgvNU35i+68M4b1ZHLZtYFT5QObFLV+ZkmJYcwKdiw==",
 					"dev": true,
 					"requires": {
 						"cliui": "^4.0.0",
@@ -12143,14 +13336,16 @@
 					"dependencies": {
 						"y18n": {
 							"version": "3.2.1",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
 							"dev": true
 						}
 					}
 				},
 				"yargs-parser": {
 					"version": "9.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
 					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0"
@@ -12174,12 +13369,6 @@
 					"dev": true
 				}
 			}
-		},
-		"number-is-nan": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-			"dev": true
 		},
 		"oauth-sign": {
 			"version": "0.9.0",
@@ -12261,6 +13450,15 @@
 			"dev": true,
 			"requires": {
 				"wrappy": "1"
+			}
+		},
+		"onetime": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+			"integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+			"dev": true,
+			"requires": {
+				"mimic-fn": "^2.1.0"
 			}
 		},
 		"only": {
@@ -13085,6 +14283,16 @@
 				}
 			}
 		},
+		"restore-cursor": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+			"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+			"dev": true,
+			"requires": {
+				"onetime": "^5.1.0",
+				"signal-exit": "^3.0.2"
+			}
+		},
 		"retry": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
@@ -13122,13 +14330,10 @@
 			}
 		},
 		"run-async": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.0.tgz",
-			"integrity": "sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==",
-			"dev": true,
-			"requires": {
-				"is-promise": "^2.1.0"
-			}
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+			"integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+			"dev": true
 		},
 		"run-parallel": {
 			"version": "1.1.9",
@@ -14652,9 +15857,9 @@
 			"dev": true
 		},
 		"v8-compile-cache": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
-			"integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
+			"integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
 			"dev": true
 		},
 		"valid-url": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
 		"@neovici/cosmoz-i18next": "^3.2.2",
 		"@neovici/cosmoz-page-router": "^6.0.5",
 		"@neovici/cosmoz-utils": "^3.7.0",
-		"@polymer/iron-flex-layout": "^3.0.0",
 		"@polymer/iron-resizable-behavior": "^3.0.1",
 		"@polymer/paper-icon-button": "^3.0.0",
 		"@polymer/paper-spinner": "^3.0.0",
@@ -71,8 +70,8 @@
 		"haunted": "^4.7.0"
 	},
 	"devDependencies": {
-		"@commitlint/cli": "^8.3.5",
-		"@commitlint/config-conventional": "^8.3.4",
+		"@commitlint/cli": "^9.0.1",
+		"@commitlint/config-conventional": "^9.0.1",
 		"@neovici/eslint-config": "^1.2.2",
 		"@open-wc/testing": "^2.5.18",
 		"@open-wc/testing-karma": "^3.4.4",
@@ -83,7 +82,7 @@
 		"@webcomponents/webcomponentsjs": "^2.4.3",
 		"deepmerge": "^4.2.2",
 		"es-dev-server": "^1.55.0",
-		"eslint": "^6.8.0",
+		"eslint": "^7.3.0",
 		"husky": "^4.2.3",
 		"karma": "^5.1.0",
 		"karma-firefox-launcher": "^1.3.0",

--- a/test/helpers/cosmoz-data-nav-test-view.js
+++ b/test/helpers/cosmoz-data-nav-test-view.js
@@ -1,6 +1,4 @@
 import '@polymer/paper-icon-button/paper-icon-button';
-import '@polymer/iron-flex-layout/iron-flex-layout';
-import '@polymer/iron-flex-layout/iron-flex-layout-classes';
 
 import { PolymerElement } from '@polymer/polymer/polymer-element';
 import { html } from '@polymer/polymer/lib/utils/html-tag';
@@ -14,12 +12,14 @@ class CosmozDataNavTestView extends dataNavUserMixin(PolymerElement) {
 		return html`
 			<style>
 				.text {
+					flex: 1;
+					flex-basis: 0.000000001px;
 					font-size: 300px;
 					line-height: 360px;
 					text-align: center;
 				}
 			</style>
-			<div class="flex text">[[ item.id ]]</div>
+			<div class="text">[[ item.id ]]</div>
 			<div>
 				<paper-icon-button slot="actions" disabled$="[[ prevDisabled ]]" icon="chevron-left" cosmoz-data-nav-select="-1"></paper-icon-button>
 				<span>[[ index ]]</span>

--- a/test/helpers/utils.js
+++ b/test/helpers/utils.js
@@ -1,9 +1,6 @@
 import {
 	fixture, html
 } from '@open-wc/testing';
-import '@polymer/polymer/lib/elements/custom-style.js';
-import '@polymer/iron-flex-layout/iron-flex-layout.js';
-import '@polymer/iron-flex-layout/iron-flex-layout-classes.js';
 
 export const
 	flushRenderQueue = nav => {
@@ -33,21 +30,19 @@ export const
 		}
 	},
 	visibilityFixture = html`
-		<custom-style>
-			<style include="iron-flex iron-positioning">
-				cosmoz-data-nav {
-					display: block;
-					width: 455px;
-					height: 400px;
-					position: relative;
-				}
-			</style>
-		</custom-style>
+		<style>
+			cosmoz-data-nav {
+				display: block;
+				width: 455px;
+				height: 400px;
+				position: relative;
+			}
+		</style>
 	`,
 	defaultsFixture = html`
 		<cosmoz-data-nav>
 			<template>
-				<cosmoz-data-nav-test-view class="fit layout vertical" item="{{ item }}" index="[[ index ]]">
+				<cosmoz-data-nav-test-view item="{{ item }}" index="[[ index ]]">
 				</cosmoz-data-nav-test-view>
 			</template>
 		</cosmoz-data-nav>


### PR DESCRIPTION
Dropped the iron-flex-layout dependency and tried redefining missing
styles in the proper contexts. A lot of styles seemed unnecessary from
the demo- and test standpoint, let's see if it remains so in production/FE.
Otherwise we should add tests.

Rewrote the demo with haunted since current version failed for me.

Upgraded dependencies.

Signed-off-by: Patrik Kullman <patrik.kullman@neovici.se>