### PR TITLE
feat: renderItem: render templates with lit-html

### DIFF
--- a/cosmoz-data-nav.js
+++ b/cosmoz-data-nav.js
@@ -350,7 +350,11 @@ class CosmozDataNav extends hauntedPolymer('haunted', useDataNav)(mixinBehaviors
 
 		this.splice('_elements', 0, this._elements.length, this._createElement())
 			.forEach(element => {
-				this._removeInstance(element.__instance);
+				if (this.renderItem) {
+					element.removeChild(element.__instance);
+				} else {
+					this._removeInstance(element.__instance);
+				}
 				element.removeChild(element.__incomplete);
 				element.__instance = element.__incomplete = null;
 			});

--- a/cosmoz-data-nav.js
+++ b/cosmoz-data-nav.js
@@ -154,6 +154,10 @@ class CosmozDataNav extends hauntedPolymer('haunted', useDataNav)(mixinBehaviors
 				value: 1
 			},
 
+			renderItem: {
+				type: Function
+			},
+
 			/**
 			 * The currently selected index.
 			 */
@@ -353,7 +357,7 @@ class CosmozDataNav extends hauntedPolymer('haunted', useDataNav)(mixinBehaviors
 	}
 
 	_onTemplatesChange(change) {
-		if (!this._elementTemplate) {
+		if (!this._elementTemplate && !this.renderItem) {
 			const templates = change.addedNodes.filter(n => n.nodeType === Node.ELEMENT_NODE && n.tagName === 'TEMPLATE'),
 				elementTemplate = templates[0];
 
@@ -425,6 +429,11 @@ class CosmozDataNav extends hauntedPolymer('haunted', useDataNav)(mixinBehaviors
 			incDiv = document.createElement('div');
 		element.appendChild(incDiv);
 		element.__incomplete = incDiv;
+		if (this.renderItem) {
+			const instDiv = document.createElement('div');
+			element.appendChild(instDiv);
+			element.__instance = instDiv;
+		}
 		element.setAttribute('slot', 'items');
 		element.classList.add('animatable');
 		return element;
@@ -553,12 +562,13 @@ class CosmozDataNav extends hauntedPolymer('haunted', useDataNav)(mixinBehaviors
 			return;
 		}
 
-		// update instance's data-nav related props
-		const instance = renderedElement.__instance;
-		Object.entries(this._getBaseProps(index))
-			.forEach(([key, value]) => instance._setPendingProperty(key, value));
-		instance._flushProperties();
-
+		if (!this.renderItem) {
+			// update instance's data-nav related props
+			const instance = renderedElement.__instance;
+			Object.entries(this._getBaseProps(index))
+				.forEach(([key, value]) => instance._setPendingProperty(key, value));
+			instance._flushProperties();
+		}
 		this._elements.splice(renderedIndex, 1);
 		this.splice('_elements', elementIndex, 0, renderedElement);
 	}
@@ -715,7 +725,7 @@ class CosmozDataNav extends hauntedPolymer('haunted', useDataNav)(mixinBehaviors
 			baseProps = this._getBaseProps(index),
 			instance = element.__instance;
 
-		if (instance) {
+		if (!this.renderItem && instance) {
 			Object.assign(instance, baseProps);
 		}
 
@@ -733,7 +743,7 @@ class CosmozDataNav extends hauntedPolymer('haunted', useDataNav)(mixinBehaviors
 			return;
 		}
 
-		instance._showHideChildren(true);
+		this._toggleInstance(instance, false);
 	}
 
 	_removeInstance(instance) {
@@ -865,7 +875,7 @@ class CosmozDataNav extends hauntedPolymer('haunted', useDataNav)(mixinBehaviors
 	 * @return {Boolean} True if the element should be notified
 	 */
 	resizerShouldNotify(resizable) {
-		return this._isDescendantOfElementInstance(resizable, this.selectedElement);
+		return !this.renderItem && this._isDescendantOfElementInstance(resizable, this.selectedElement);
 	}
 
 	/**
@@ -900,7 +910,7 @@ class CosmozDataNav extends hauntedPolymer('haunted', useDataNav)(mixinBehaviors
 	 * @return {Boolean} True if descendant has been notified.
 	 */
 	_notifyElementResize(element = this.selectedElement) {
-		if (!this.isConnected || !element) {
+		if (this.renderItem || !this.isConnected || !element) {
 			return false;
 		}
 
@@ -948,8 +958,6 @@ class CosmozDataNav extends hauntedPolymer('haunted', useDataNav)(mixinBehaviors
 			instance = new this._elementCtor(props);
 
 		element.__instance = instance;
-		element.item = item;
-		element._reset = false;
 		element.appendChild(instance.root);
 	}
 
@@ -1017,17 +1025,32 @@ class CosmozDataNav extends hauntedPolymer('haunted', useDataNav)(mixinBehaviors
 		this._renderRan = needsRender;
 
 		if (needsRender) {
+			element.item = item;
+			element._reset = false;
+			if (this.renderItem) {
+				render(this.renderItem(item, idx, this.items), element.__instance);
+				this._toggleInstance(element.__instance, true);
+				return;
+			}
 			this._forwardItem(element, item, idx);
 			if (isSelected) {
 				return idx;
 			}
 		} else if (isSelected) {
 			// make sure that the instance is visible (may be a re-aligned invisible instance)
-			element.__instance._showHideChildren(false);
+			this._toggleInstance(element.__instance, true);
 			// resize is a expensive operation
 			this._renderRan = this._notifyElementResize();
 			this._setSelectedInstance(this._getInstance(element));
 		}
+	}
+
+	_toggleInstance(inst, show) {
+		if (this.renderItem) {
+			inst.style.display = show ? 'block' : 'none';
+			return;
+		}
+		inst._showHideChildren(!show);
 	}
 
 	_getItemId(item) {

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -26,7 +26,13 @@ const asyncs = {},
 				console.log('on need data', id);
 				asyncs[id] = setTimeout(() => dataNav.setItemById(id, { id }), 500);
 			},
-			computeJSON = index => JSON.stringify(items[index]);
+			computeJSON = index => JSON.stringify(items[index]),
+			renderItem = (item, index, items) => html`
+                <cosmoz-demo-view
+                    .item="${ item }" .index="${ index }"
+                    .prevDisabled="${ index < 1 }" .nextDisabled="${ index > items.length - 2 }">
+                </cosmoz-demo-view>
+            `;
 
 		useEffect(() => {
 			if (instance?.dataset == null) {
@@ -65,13 +71,8 @@ const asyncs = {},
                     @selected-changed="${ e => setSelected(e?.detail?.value) }"
                     @selected-item-changed="${ e => setSelItem(e?.detail?.value) }"
                     @selected-instance-changed="${ e => setInstance(e?.detail?.value) }"
+                    .renderItem="${ renderItem }"
             >
-                <template>
-                    <cosmoz-demo-view
-                        item="{{ item }}" index="[[ index ]]"
-                        prev-disabled="[[ prevDisabled ]]" next-disabled="[[ nextDisabled ]]">
-                    </cosmoz-demo-view>
-                </template>
             </cosmoz-data-nav>
             <paper-textarea value="${ computeJSON(selected) }"></paper-textarea>
             <div>Selected: ${ JSON.stringify(selItem) }</div>

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import {
 	assert, fixture, html, oneEvent, waitUntil
 } from '@open-wc/testing';
@@ -398,5 +399,33 @@ suite('renderQueue', () => {
 		nav._elements.forEach((el, id) => {
 			assert.deepEqual(el.__instance.item, { id });
 		});
+	});
+});
+
+suite('renderItem', () => {
+	let nav,
+		itemsRendered = 0;
+	const renderItem = (item, index) => {
+		itemsRendered += 1;
+		return html`
+			<cosmoz-data-nav-test-view class="fit layout vertical" item="${ item }" index="${ index }">
+			</cosmoz-data-nav-test-view>
+		`;
+	};
+
+	suiteSetup(async () => {
+		[, nav] = await Promise.all([
+			fixture(visibilityFixture),
+			setupFixture(html`
+				<cosmoz-data-nav .renderItem="${ renderItem }">
+				</cosmoz-data-nav>
+			`)
+		]);
+	});
+
+	test('renders items', async () => {
+		nav.items = [{ id: '0' }, { id: '1' }, { id: '2' }];
+		flushRenderQueue(nav);
+		assert.equal(itemsRendered, nav.items.map(nav.isIncompleteFn).filter(i => !i).length);
 	});
 });


### PR DESCRIPTION
This adds support to pass data-nav a `renderItem` function,
which should return a lit-html TemplateResult when invoked.
If set, this will use lit-html rendering instead of the current
Polymer template handling.

The resize-forwarding behavior of iron-resize has been disabled
when using renderItem. If resizing issues occur when migrating
to renderItem, switch to ResizeObserver in the data-nav view.