### PR TITLE
fix: mark hash params as read when hash value is empty

### DIFF
--- a/cosmoz-data-nav.js
+++ b/cosmoz-data-nav.js
@@ -978,8 +978,14 @@ class CosmozDataNav extends hauntedPolymer('haunted', useDataNav)(PolymerElement
 		}
 
 		const path = ['_routeHashParams', hashParam],
-			hashValue = this.get(path),
-			selection = this.items.findIndex(i => this._getItemId(i) === hashValue);
+			hashValue = this.get(path);
+
+		if (!hashValue) {
+			this._readFromHashOnce = true;
+			return;
+		}
+
+		const selection = this.items.findIndex(i => this._getItemId(i) === hashValue);
 
 		if (selection < 0 || selection === this.selected) {
 			return;


### PR DESCRIPTION
An improvement for #144 when hash param is empty on first read