### PR TITLE
fix: only add the in class when we really want to reset animationg

### DIFF
--- a/cosmoz-data-nav.js
+++ b/cosmoz-data-nav.js
@@ -601,7 +601,7 @@ class CosmozDataNav extends hauntedPolymer('haunted', useDataNav)(PolymerElement
 			this._elements.forEach(el => el.classList.remove('selected'));
 		}
 
-		classes.toggle('in', !!this.animating);
+		classes.toggle('in', animating);
 		classes.add('selected');
 
 		if (!animating) {


### PR DESCRIPTION
When we don't have a `prev` we do not really have an animation so we shouldn't
reset the animation by adding the `in` class.
