### PR TITLE
fix(cosmoz-data-nav): prevent creation of a new stacking context

### DIFF
--- a/cosmoz-data-nav.js
+++ b/cosmoz-data-nav.js
@@ -36,11 +36,6 @@ class CosmozDataNav extends hauntedPolymer('haunted', useDataNav)(PolymerElement
 				}
 
 				#items,
-				#items > ::slotted(.animatable){
-					transform: translateX(0px);
-				}
-
-				#items,
 				#items > ::slotted(.animatable) {
 					position: absolute;
 					top: 0;


### PR DESCRIPTION
Because of the default 0px transform data-nav creates a new stacking context
that prevents us from correctly positioning elements in dropdown menu
without moving to body.
