### PR TITLE
fix: use display contents for renderItem instance

### DIFF
--- a/cosmoz-data-nav.js
+++ b/cosmoz-data-nav.js
@@ -930,7 +930,7 @@ class CosmozDataNav extends hauntedPolymer('haunted', useDataNav)(PolymerElement
 
 	_toggleInstance(inst, show) {
 		if (this.renderItem) {
-			inst.style.display = show ? 'block' : 'none';
+			inst.style.display = show ? 'contents' : 'none';
 			return;
 		}
 		inst?._showHideChildren(!show);


### PR DESCRIPTION
Use display contents for instance when using renderItem to prevent
requiring position absolute to 100% side children.
