### PR TITLE
feat: support cosmoz-bottom-bar v9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "7.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@neovici/cosmoz-bottom-bar": "^7.0.0 || ^8.0.0",
+				"@neovici/cosmoz-bottom-bar": "^9.5.0",
 				"@neovici/cosmoz-i18next": "^3.0.0",
 				"@neovici/cosmoz-utils": "^6.0.0",
 				"@pionjs/pion": "^2.0.0",
@@ -1186,13 +1186,13 @@
 			}
 		},
 		"node_modules/@neovici/cosmoz-bottom-bar": {
-			"version": "8.1.1",
-			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-bottom-bar/-/cosmoz-bottom-bar-8.1.1.tgz",
-			"integrity": "sha512-NIIa1ORKPUCkvf2jg9cOTy5EXl59MD1TKlDz8KjBBPblmkWl836VmJ4wbqQFX2qSHiVivjUBs12UCjlMdH4OSw==",
+			"version": "9.5.0",
+			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-bottom-bar/-/cosmoz-bottom-bar-9.5.0.tgz",
+			"integrity": "sha512-mGpmJQP8c2yxuIiE4k/wSvLXQWzhC7Q2jZOe+TuAWKQxnbudl6lknN2PTWjAt4qDXCuC6Oz7JRTZIeTabVmxkg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@neovici/cosmoz-collapse": "^1.5.0",
-				"@neovici/cosmoz-dropdown": "^4.0.0 || ^5.0.0",
+				"@neovici/cosmoz-dropdown": "^6.0.0",
 				"@neovici/cosmoz-utils": "^6.13.1",
 				"@pionjs/pion": "^2.5.2",
 				"@polymer/polymer": "^3.3.0",
@@ -1209,16 +1209,15 @@
 			}
 		},
 		"node_modules/@neovici/cosmoz-dropdown": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-dropdown/-/cosmoz-dropdown-5.4.0.tgz",
-			"integrity": "sha512-YxPzF2ghVatoo+5T4aAwpAMU+pB96NgStDCpkCwf2Qf/oQH0Gm2YIsZ3DYenaRgylHW6+MDV+1HEvASMacMmng==",
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-dropdown/-/cosmoz-dropdown-6.5.0.tgz",
+			"integrity": "sha512-zHfecK77qERy/lA4W6K1KFVsej67hV1b0s0qMVQGBVL84l+spiCJZjkkC4my3A7dLBvt4BTpxv2wFQ3rNzt/0g==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@floating-ui/dom": "^1.6.12",
 				"@neovici/cosmoz-utils": "^6.8.1",
 				"@pionjs/pion": "^2.5.2",
-				"lit-html": "^3.1.2",
-				"position.js": "^1.1.0"
+				"lit-html": "^3.1.2"
 			}
 		},
 		"node_modules/@neovici/cosmoz-i18next": {
@@ -13558,12 +13557,6 @@
 			"engines": {
 				"node": ">= 10.12"
 			}
-		},
-		"node_modules/position.js": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/position.js/-/position.js-1.1.0.tgz",
-			"integrity": "sha512-h/GJiK6nxrZOhmLgUYfGZhjvbpuocyL55Ggv8+k4BR/RHqmXGVIHwhYMeZh+J8HfXNLUtr2RbjOK+4LpTwV7vg==",
-			"license": "MIT"
 		},
 		"node_modules/possible-typed-array-names": {
 			"version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 		]
 	},
 	"dependencies": {
-		"@neovici/cosmoz-bottom-bar": "^7.0.0 || ^8.0.0",
+		"@neovici/cosmoz-bottom-bar": "^7.0.0 || ^8.0.0 || ^9.0.0",
 		"@neovici/cosmoz-i18next": "^3.0.0",
 		"@neovici/cosmoz-utils": "^6.0.0",
 		"@pionjs/pion": "^2.0.0",


### PR DESCRIPTION
## Summary

- Expand `@neovici/cosmoz-bottom-bar` dependency range to include `^9.0.0`
- Enables `cosmoz-frontend` to deduplicate bottom-bar versions (currently has v8.0.1 and v9.0.5 nested)
- The `slot="extra"` usage in `use-incomplete-template.js` is preserved in v9, so no code changes required

## Related

Fixes NEO-803