### PR TITLE
chore: upgrade semantic-release to v25

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "7.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@neovici/cosmoz-bottom-bar": "^9.5.0",
+				"@neovici/cosmoz-bottom-bar": "^7.0.0 || ^8.0.0 || ^9.0.0",
 				"@neovici/cosmoz-i18next": "^3.0.0",
 				"@neovici/cosmoz-utils": "^6.0.0",
 				"@pionjs/pion": "^2.0.0",
@@ -30,10 +30,59 @@
 				"@webcomponents/webcomponentsjs": "^2.5.0",
 				"husky": "^8.0.0",
 				"lint-staged": "^16.2.7",
-				"semantic-release": "^24.0.0",
+				"semantic-release": "^25.0.0",
 				"sinon": "^17.0.0",
 				"web-animations-js": "^2.3.1"
 			}
+		},
+		"node_modules/@actions/core": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@actions/core/-/core-2.0.3.tgz",
+			"integrity": "sha512-Od9Thc3T1mQJYddvVPM4QGiLUewdh+3txmDYHHxoNdkqysR1MbCT+rFOtNUxYAz+7+6RIsqipVahY2GJqGPyxA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@actions/exec": "^2.0.0",
+				"@actions/http-client": "^3.0.2"
+			}
+		},
+		"node_modules/@actions/exec": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@actions/exec/-/exec-2.0.0.tgz",
+			"integrity": "sha512-k8ngrX2voJ/RIN6r9xB82NVqKpnMRtxDoiO+g3olkIUpQNqjArXrCQceduQZCQj3P3xm32pChRLqRrtXTlqhIw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@actions/io": "^2.0.0"
+			}
+		},
+		"node_modules/@actions/http-client": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-3.0.2.tgz",
+			"integrity": "sha512-JP38FYYpyqvUsz+Igqlc/JG6YO9PaKuvqjM3iGvaLqFnJ7TFmcLyy2IDrY0bI0qCQug8E9K+elv5ZNfw62ZJzA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tunnel": "^0.0.6",
+				"undici": "^6.23.0"
+			}
+		},
+		"node_modules/@actions/http-client/node_modules/undici": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
+			"integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.17"
+			}
+		},
+		"node_modules/@actions/io": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@actions/io/-/io-2.0.0.tgz",
+			"integrity": "sha512-Jv33IN09XLO+0HS79aaODsvIRyduiF7NY/F6LYeK5oeUmrsz7aFdRphQjFoESF4jS7lMauDOttKALcpapVDIAg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@babel/code-frame": {
 			"version": "7.28.6",
@@ -1344,36 +1393,19 @@
 			"license": "MIT"
 		},
 		"node_modules/@octokit/plugin-paginate-rest": {
-			"version": "13.2.1",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-13.2.1.tgz",
-			"integrity": "sha512-Tj4PkZyIL6eBMYcG/76QGsedF0+dWVeLhYprTmuFVVxzDW7PQh23tM0TP0z+1MvSkxB29YFZwnUX+cXfTiSdyw==",
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+			"integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^15.0.1"
+				"@octokit/types": "^16.0.0"
 			},
 			"engines": {
 				"node": ">= 20"
 			},
 			"peerDependencies": {
 				"@octokit/core": ">=6"
-			}
-		},
-		"node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
-			"version": "26.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-26.0.0.tgz",
-			"integrity": "sha512-7AtcfKtpo77j7Ts73b4OWhOZHTKo/gGY8bB3bNBQz4H+GRSWqx2yvj8TXRsbdTE0eRmYmXOEY66jM7mJ7LzfsA==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
-			"version": "15.0.2",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-15.0.2.tgz",
-			"integrity": "sha512-rR+5VRjhYSer7sC51krfCctQhVTmjyUMAaShfPB8mscVa8tSoLyon3coxQmXu0ahJoLVWl8dSGD/3OGZlFV44Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@octokit/openapi-types": "^26.0.0"
 			}
 		},
 		"node_modules/@octokit/plugin-retry": {
@@ -2364,14 +2396,14 @@
 			}
 		},
 		"node_modules/@semantic-release/github": {
-			"version": "11.0.6",
-			"resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-11.0.6.tgz",
-			"integrity": "sha512-ctDzdSMrT3H+pwKBPdyCPty6Y47X8dSrjd3aPZ5KKIKKWTwZBE9De8GtsH3TyAlw3Uyo2stegMx6rJMXKpJwJA==",
+			"version": "12.0.2",
+			"resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-12.0.2.tgz",
+			"integrity": "sha512-qyqLS+aSGH1SfXIooBKjs7mvrv0deg8v+jemegfJg1kq6ji+GJV8CO08VJDEsvjp3O8XJmTTIAjjZbMzagzsdw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/core": "^7.0.0",
-				"@octokit/plugin-paginate-rest": "^13.0.0",
+				"@octokit/plugin-paginate-rest": "^14.0.0",
 				"@octokit/plugin-retry": "^8.0.0",
 				"@octokit/plugin-throttling": "^11.0.0",
 				"@semantic-release/error": "^4.0.0",
@@ -2385,10 +2417,11 @@
 				"mime": "^4.0.0",
 				"p-filter": "^4.0.0",
 				"tinyglobby": "^0.2.14",
+				"undici": "^7.0.0",
 				"url-join": "^5.0.0"
 			},
 			"engines": {
-				"node": ">=20.8.1"
+				"node": "^22.14.0 || >= 24.10.0"
 			},
 			"peerDependencies": {
 				"semantic-release": ">=24.1.0"
@@ -2464,28 +2497,30 @@
 			}
 		},
 		"node_modules/@semantic-release/npm": {
-			"version": "12.0.2",
-			"resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-12.0.2.tgz",
-			"integrity": "sha512-+M9/Lb35IgnlUO6OSJ40Ie+hUsZLuph2fqXC/qrKn0fMvUU/jiCjpoL6zEm69vzcmaZJ8yNKtMBEKHWN49WBbQ==",
+			"version": "13.1.3",
+			"resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-13.1.3.tgz",
+			"integrity": "sha512-q7zreY8n9V0FIP1Cbu63D+lXtRAVAIWb30MH5U3TdrfXt6r2MIrWCY0whAImN53qNvSGp0Zt07U95K+Qp9GpEg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
+				"@actions/core": "^2.0.0",
 				"@semantic-release/error": "^4.0.0",
 				"aggregate-error": "^5.0.0",
+				"env-ci": "^11.2.0",
 				"execa": "^9.0.0",
 				"fs-extra": "^11.0.0",
 				"lodash-es": "^4.17.21",
 				"nerf-dart": "^1.0.0",
 				"normalize-url": "^8.0.0",
-				"npm": "^10.9.3",
+				"npm": "^11.6.2",
 				"rc": "^1.2.8",
-				"read-pkg": "^9.0.0",
+				"read-pkg": "^10.0.0",
 				"registry-auth-token": "^5.0.0",
 				"semver": "^7.1.2",
 				"tempy": "^3.0.0"
 			},
 			"engines": {
-				"node": ">=20.8.1"
+				"node": "^22.14.0 || >= 24.10.0"
 			},
 			"peerDependencies": {
 				"semantic-release": ">=20.1.0"
@@ -2627,6 +2662,21 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/@semantic-release/npm/node_modules/normalize-package-data": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-8.0.0.tgz",
+			"integrity": "sha512-RWk+PI433eESQ7ounYxIp67CYuVsS1uYSonX3kA6ps/3LWfjVQa/ptEg6Y3T6uAMq1mWpX9PQ+qx+QaHpsc7gQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"hosted-git-info": "^9.0.0",
+				"semver": "^7.3.5",
+				"validate-npm-package-license": "^3.0.4"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
 		"node_modules/@semantic-release/npm/node_modules/npm-run-path": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
@@ -2644,6 +2694,37 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/@semantic-release/npm/node_modules/parse-json": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+			"integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.26.2",
+				"index-to-position": "^1.1.0",
+				"type-fest": "^4.39.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/parse-json/node_modules/type-fest": {
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/@semantic-release/npm/node_modules/path-key": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
@@ -2652,6 +2733,26 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/read-pkg": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-10.0.0.tgz",
+			"integrity": "sha512-A70UlgfNdKI5NSvTTfHzLQj7NJRpJ4mT5tGafkllJ4wh71oYuGm/pzphHcmW4s35iox56KSK721AihodoXSc/A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/normalize-package-data": "^2.4.4",
+				"normalize-package-data": "^8.0.0",
+				"parse-json": "^8.3.0",
+				"type-fest": "^5.2.0",
+				"unicorn-magic": "^0.3.0"
+			},
+			"engines": {
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -2678,6 +2779,22 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/type-fest": {
+			"version": "5.4.2",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.4.2.tgz",
+			"integrity": "sha512-FLEenlVYf7Zcd34ISMLo3ZzRE1gRjY1nMDTp+bQRBiPsaKyIW8K3Zr99ioHDUgA9OGuGGJPyYpNcffGmBhJfGg==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"dependencies": {
+				"tagged-tag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -7919,24 +8036,27 @@
 			}
 		},
 		"node_modules/hosted-git-info": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-8.1.0.tgz",
-			"integrity": "sha512-Rw/B2DNQaPBICNXEm8balFz9a6WpZrkCGpcWFpy7nCj+NyhSdqXipmfvtmWt9xGfp0wZnBxB+iVpLmQMYt47Tw==",
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
+			"integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"lru-cache": "^10.0.1"
+				"lru-cache": "^11.1.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/hosted-git-info/node_modules/lru-cache": {
-			"version": "10.4.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"version": "11.2.5",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
+			"integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
 			"dev": true,
-			"license": "ISC"
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
 		},
 		"node_modules/html-escaper": {
 			"version": "2.0.2",
@@ -10180,15 +10300,16 @@
 			}
 		},
 		"node_modules/npm": {
-			"version": "10.9.4",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-10.9.4.tgz",
-			"integrity": "sha512-OnUG836FwboQIbqtefDNlyR0gTHzIfwRfE3DuiNewBvnMnWEpB0VEXwBlFVgqpNzIgYo/MHh3d2Hel/pszapAA==",
+			"version": "11.8.0",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-11.8.0.tgz",
+			"integrity": "sha512-n19sJeW+RGKdkHo8SCc5xhSwkKhQUFfZaFzSc+EsYXLjSqIV0tl72aDYQVuzVvfrbysGwdaQsNLNy58J10EBSQ==",
 			"bundleDependencies": [
 				"@isaacs/string-locale-compare",
 				"@npmcli/arborist",
 				"@npmcli/config",
 				"@npmcli/fs",
 				"@npmcli/map-workspaces",
+				"@npmcli/metavuln-calculator",
 				"@npmcli/package-json",
 				"@npmcli/promise-spawn",
 				"@npmcli/redact",
@@ -10213,7 +10334,6 @@
 				"libnpmdiff",
 				"libnpmexec",
 				"libnpmfund",
-				"libnpmhook",
 				"libnpmorg",
 				"libnpmpack",
 				"libnpmpublish",
@@ -10227,7 +10347,6 @@
 				"ms",
 				"node-gyp",
 				"nopt",
-				"normalize-package-data",
 				"npm-audit-report",
 				"npm-install-checks",
 				"npm-package-arg",
@@ -10250,8 +10369,7 @@
 				"tiny-relative-date",
 				"treeverse",
 				"validate-npm-package-name",
-				"which",
-				"write-file-atomic"
+				"which"
 			],
 			"dev": true,
 			"license": "Artistic-2.0",
@@ -10264,80 +10382,78 @@
 			],
 			"dependencies": {
 				"@isaacs/string-locale-compare": "^1.1.0",
-				"@npmcli/arborist": "^8.0.1",
-				"@npmcli/config": "^9.0.0",
-				"@npmcli/fs": "^4.0.0",
-				"@npmcli/map-workspaces": "^4.0.2",
-				"@npmcli/package-json": "^6.2.0",
-				"@npmcli/promise-spawn": "^8.0.2",
-				"@npmcli/redact": "^3.2.2",
-				"@npmcli/run-script": "^9.1.0",
-				"@sigstore/tuf": "^3.1.1",
-				"abbrev": "^3.0.1",
+				"@npmcli/arborist": "^9.1.10",
+				"@npmcli/config": "^10.5.0",
+				"@npmcli/fs": "^5.0.0",
+				"@npmcli/map-workspaces": "^5.0.3",
+				"@npmcli/metavuln-calculator": "^9.0.3",
+				"@npmcli/package-json": "^7.0.4",
+				"@npmcli/promise-spawn": "^9.0.1",
+				"@npmcli/redact": "^4.0.0",
+				"@npmcli/run-script": "^10.0.3",
+				"@sigstore/tuf": "^4.0.1",
+				"abbrev": "^4.0.0",
 				"archy": "~1.0.0",
-				"cacache": "^19.0.1",
-				"chalk": "^5.4.1",
-				"ci-info": "^4.2.0",
+				"cacache": "^20.0.3",
+				"chalk": "^5.6.2",
+				"ci-info": "^4.3.1",
 				"cli-columns": "^4.0.0",
 				"fastest-levenshtein": "^1.0.16",
 				"fs-minipass": "^3.0.3",
-				"glob": "^10.4.5",
+				"glob": "^13.0.0",
 				"graceful-fs": "^4.2.11",
-				"hosted-git-info": "^8.1.0",
-				"ini": "^5.0.0",
-				"init-package-json": "^7.0.2",
-				"is-cidr": "^5.1.1",
-				"json-parse-even-better-errors": "^4.0.0",
-				"libnpmaccess": "^9.0.0",
-				"libnpmdiff": "^7.0.1",
-				"libnpmexec": "^9.0.1",
-				"libnpmfund": "^6.0.1",
-				"libnpmhook": "^11.0.0",
-				"libnpmorg": "^7.0.0",
-				"libnpmpack": "^8.0.1",
-				"libnpmpublish": "^10.0.1",
-				"libnpmsearch": "^8.0.0",
-				"libnpmteam": "^7.0.0",
-				"libnpmversion": "^7.0.0",
-				"make-fetch-happen": "^14.0.3",
-				"minimatch": "^9.0.5",
+				"hosted-git-info": "^9.0.2",
+				"ini": "^6.0.0",
+				"init-package-json": "^8.2.4",
+				"is-cidr": "^6.0.1",
+				"json-parse-even-better-errors": "^5.0.0",
+				"libnpmaccess": "^10.0.3",
+				"libnpmdiff": "^8.0.13",
+				"libnpmexec": "^10.1.12",
+				"libnpmfund": "^7.0.13",
+				"libnpmorg": "^8.0.1",
+				"libnpmpack": "^9.0.13",
+				"libnpmpublish": "^11.1.3",
+				"libnpmsearch": "^9.0.1",
+				"libnpmteam": "^8.0.2",
+				"libnpmversion": "^8.0.3",
+				"make-fetch-happen": "^15.0.3",
+				"minimatch": "^10.1.1",
 				"minipass": "^7.1.1",
 				"minipass-pipeline": "^1.2.4",
 				"ms": "^2.1.2",
-				"node-gyp": "^11.2.0",
-				"nopt": "^8.1.0",
-				"normalize-package-data": "^7.0.0",
-				"npm-audit-report": "^6.0.0",
-				"npm-install-checks": "^7.1.1",
-				"npm-package-arg": "^12.0.2",
-				"npm-pick-manifest": "^10.0.0",
-				"npm-profile": "^11.0.1",
-				"npm-registry-fetch": "^18.0.2",
-				"npm-user-validate": "^3.0.0",
-				"p-map": "^7.0.3",
-				"pacote": "^19.0.1",
-				"parse-conflict-json": "^4.0.0",
-				"proc-log": "^5.0.0",
+				"node-gyp": "^12.1.0",
+				"nopt": "^9.0.0",
+				"npm-audit-report": "^7.0.0",
+				"npm-install-checks": "^8.0.0",
+				"npm-package-arg": "^13.0.2",
+				"npm-pick-manifest": "^11.0.3",
+				"npm-profile": "^12.0.1",
+				"npm-registry-fetch": "^19.1.1",
+				"npm-user-validate": "^4.0.0",
+				"p-map": "^7.0.4",
+				"pacote": "^21.0.4",
+				"parse-conflict-json": "^5.0.1",
+				"proc-log": "^6.1.0",
 				"qrcode-terminal": "^0.12.0",
-				"read": "^4.1.0",
-				"semver": "^7.7.2",
+				"read": "^5.0.1",
+				"semver": "^7.7.3",
 				"spdx-expression-parse": "^4.0.0",
-				"ssri": "^12.0.0",
-				"supports-color": "^9.4.0",
-				"tar": "^6.2.1",
+				"ssri": "^13.0.0",
+				"supports-color": "^10.2.2",
+				"tar": "^7.5.4",
 				"text-table": "~0.2.0",
-				"tiny-relative-date": "^1.3.0",
+				"tiny-relative-date": "^2.0.2",
 				"treeverse": "^3.0.0",
-				"validate-npm-package-name": "^6.0.1",
-				"which": "^5.0.0",
-				"write-file-atomic": "^6.0.0"
+				"validate-npm-package-name": "^7.0.2",
+				"which": "^6.0.0"
 			},
 			"bin": {
 				"npm": "bin/npm-cli.js",
 				"npx": "bin/npx-cli.js"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm-run-path": {
@@ -10353,71 +10469,25 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/npm/node_modules/@isaacs/cliui": {
-			"version": "8.0.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"string-width": "^5.1.2",
-				"string-width-cjs": "npm:string-width@^4.2.0",
-				"strip-ansi": "^7.0.1",
-				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-				"wrap-ansi": "^8.1.0",
-				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-			"version": "6.1.0",
+		"node_modules/npm/node_modules/@isaacs/balanced-match": {
+			"version": "4.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+				"node": "20 || >=22"
 			}
 		},
-		"node_modules/npm/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
-			"version": "9.2.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
-		},
-		"node_modules/npm/node_modules/@isaacs/cliui/node_modules/string-width": {
-			"version": "5.1.2",
+		"node_modules/npm/node_modules/@isaacs/brace-expansion": {
+			"version": "5.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"eastasianwidth": "^0.2.0",
-				"emoji-regex": "^9.2.2",
-				"strip-ansi": "^7.0.1"
+				"@isaacs/balanced-match": "^4.0.1"
 			},
 			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-			"version": "7.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/npm/node_modules/@isaacs/fs-minipass": {
@@ -10439,7 +10509,7 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/@npmcli/agent": {
-			"version": "3.0.0",
+			"version": "4.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -10447,83 +10517,81 @@
 				"agent-base": "^7.1.0",
 				"http-proxy-agent": "^7.0.0",
 				"https-proxy-agent": "^7.0.1",
-				"lru-cache": "^10.0.1",
+				"lru-cache": "^11.2.1",
 				"socks-proxy-agent": "^8.0.3"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/arborist": {
-			"version": "8.0.1",
+			"version": "9.1.10",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"@isaacs/string-locale-compare": "^1.1.0",
-				"@npmcli/fs": "^4.0.0",
-				"@npmcli/installed-package-contents": "^3.0.0",
-				"@npmcli/map-workspaces": "^4.0.1",
-				"@npmcli/metavuln-calculator": "^8.0.0",
-				"@npmcli/name-from-folder": "^3.0.0",
-				"@npmcli/node-gyp": "^4.0.0",
-				"@npmcli/package-json": "^6.0.1",
-				"@npmcli/query": "^4.0.0",
-				"@npmcli/redact": "^3.0.0",
-				"@npmcli/run-script": "^9.0.1",
-				"bin-links": "^5.0.0",
-				"cacache": "^19.0.1",
-				"common-ancestor-path": "^1.0.1",
-				"hosted-git-info": "^8.0.0",
-				"json-parse-even-better-errors": "^4.0.0",
+				"@npmcli/fs": "^5.0.0",
+				"@npmcli/installed-package-contents": "^4.0.0",
+				"@npmcli/map-workspaces": "^5.0.0",
+				"@npmcli/metavuln-calculator": "^9.0.2",
+				"@npmcli/name-from-folder": "^4.0.0",
+				"@npmcli/node-gyp": "^5.0.0",
+				"@npmcli/package-json": "^7.0.0",
+				"@npmcli/query": "^5.0.0",
+				"@npmcli/redact": "^4.0.0",
+				"@npmcli/run-script": "^10.0.0",
+				"bin-links": "^6.0.0",
+				"cacache": "^20.0.1",
+				"common-ancestor-path": "^2.0.0",
+				"hosted-git-info": "^9.0.0",
 				"json-stringify-nice": "^1.1.4",
-				"lru-cache": "^10.2.2",
-				"minimatch": "^9.0.4",
-				"nopt": "^8.0.0",
-				"npm-install-checks": "^7.1.0",
-				"npm-package-arg": "^12.0.0",
-				"npm-pick-manifest": "^10.0.0",
-				"npm-registry-fetch": "^18.0.1",
-				"pacote": "^19.0.0",
-				"parse-conflict-json": "^4.0.0",
-				"proc-log": "^5.0.0",
-				"proggy": "^3.0.0",
+				"lru-cache": "^11.2.1",
+				"minimatch": "^10.0.3",
+				"nopt": "^9.0.0",
+				"npm-install-checks": "^8.0.0",
+				"npm-package-arg": "^13.0.0",
+				"npm-pick-manifest": "^11.0.1",
+				"npm-registry-fetch": "^19.0.0",
+				"pacote": "^21.0.2",
+				"parse-conflict-json": "^5.0.1",
+				"proc-log": "^6.0.0",
+				"proggy": "^4.0.0",
 				"promise-all-reject-late": "^1.0.0",
 				"promise-call-limit": "^3.0.1",
-				"read-package-json-fast": "^4.0.0",
 				"semver": "^7.3.7",
-				"ssri": "^12.0.0",
+				"ssri": "^13.0.0",
 				"treeverse": "^3.0.0",
-				"walk-up-path": "^3.0.1"
+				"walk-up-path": "^4.0.0"
 			},
 			"bin": {
 				"arborist": "bin/index.js"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/config": {
-			"version": "9.0.0",
+			"version": "10.5.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/map-workspaces": "^4.0.1",
-				"@npmcli/package-json": "^6.0.1",
+				"@npmcli/map-workspaces": "^5.0.0",
+				"@npmcli/package-json": "^7.0.0",
 				"ci-info": "^4.0.0",
-				"ini": "^5.0.0",
-				"nopt": "^8.0.0",
-				"proc-log": "^5.0.0",
+				"ini": "^6.0.0",
+				"nopt": "^9.0.0",
+				"proc-log": "^6.0.0",
 				"semver": "^7.3.5",
-				"walk-up-path": "^3.0.1"
+				"walk-up-path": "^4.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/fs": {
-			"version": "4.0.0",
+			"version": "5.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -10531,156 +10599,125 @@
 				"semver": "^7.3.5"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/git": {
-			"version": "6.0.3",
+			"version": "7.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/promise-spawn": "^8.0.0",
-				"ini": "^5.0.0",
-				"lru-cache": "^10.0.1",
-				"npm-pick-manifest": "^10.0.0",
-				"proc-log": "^5.0.0",
+				"@npmcli/promise-spawn": "^9.0.0",
+				"ini": "^6.0.0",
+				"lru-cache": "^11.2.1",
+				"npm-pick-manifest": "^11.0.1",
+				"proc-log": "^6.0.0",
 				"promise-retry": "^2.0.1",
 				"semver": "^7.3.5",
-				"which": "^5.0.0"
+				"which": "^6.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/installed-package-contents": {
-			"version": "3.0.0",
+			"version": "4.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"npm-bundled": "^4.0.0",
-				"npm-normalize-package-bin": "^4.0.0"
+				"npm-bundled": "^5.0.0",
+				"npm-normalize-package-bin": "^5.0.0"
 			},
 			"bin": {
 				"installed-package-contents": "bin/index.js"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/map-workspaces": {
-			"version": "4.0.2",
+			"version": "5.0.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/name-from-folder": "^3.0.0",
-				"@npmcli/package-json": "^6.0.0",
-				"glob": "^10.2.2",
-				"minimatch": "^9.0.0"
+				"@npmcli/name-from-folder": "^4.0.0",
+				"@npmcli/package-json": "^7.0.0",
+				"glob": "^13.0.0",
+				"minimatch": "^10.0.3"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
-			"version": "8.0.1",
+			"version": "9.0.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"cacache": "^19.0.0",
-				"json-parse-even-better-errors": "^4.0.0",
-				"pacote": "^20.0.0",
-				"proc-log": "^5.0.0",
+				"cacache": "^20.0.0",
+				"json-parse-even-better-errors": "^5.0.0",
+				"pacote": "^21.0.0",
+				"proc-log": "^6.0.0",
 				"semver": "^7.3.5"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/@npmcli/metavuln-calculator/node_modules/pacote": {
-			"version": "20.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"@npmcli/git": "^6.0.0",
-				"@npmcli/installed-package-contents": "^3.0.0",
-				"@npmcli/package-json": "^6.0.0",
-				"@npmcli/promise-spawn": "^8.0.0",
-				"@npmcli/run-script": "^9.0.0",
-				"cacache": "^19.0.0",
-				"fs-minipass": "^3.0.0",
-				"minipass": "^7.0.2",
-				"npm-package-arg": "^12.0.0",
-				"npm-packlist": "^9.0.0",
-				"npm-pick-manifest": "^10.0.0",
-				"npm-registry-fetch": "^18.0.0",
-				"proc-log": "^5.0.0",
-				"promise-retry": "^2.0.1",
-				"sigstore": "^3.0.0",
-				"ssri": "^12.0.0",
-				"tar": "^6.1.11"
-			},
-			"bin": {
-				"pacote": "bin/index.js"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/name-from-folder": {
-			"version": "3.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/@npmcli/node-gyp": {
 			"version": "4.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/node-gyp": {
+			"version": "5.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/package-json": {
-			"version": "6.2.0",
+			"version": "7.0.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/git": "^6.0.0",
-				"glob": "^10.2.2",
-				"hosted-git-info": "^8.0.0",
-				"json-parse-even-better-errors": "^4.0.0",
-				"proc-log": "^5.0.0",
+				"@npmcli/git": "^7.0.0",
+				"glob": "^13.0.0",
+				"hosted-git-info": "^9.0.0",
+				"json-parse-even-better-errors": "^5.0.0",
+				"proc-log": "^6.0.0",
 				"semver": "^7.5.3",
 				"validate-npm-package-license": "^3.0.4"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/promise-spawn": {
-			"version": "8.0.2",
+			"version": "9.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"which": "^5.0.0"
+				"which": "^6.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/query": {
-			"version": "4.0.1",
+			"version": "5.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -10688,65 +10725,107 @@
 				"postcss-selector-parser": "^7.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/redact": {
-			"version": "3.2.2",
+			"version": "4.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/run-script": {
-			"version": "9.1.0",
+			"version": "10.0.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/node-gyp": "^4.0.0",
-				"@npmcli/package-json": "^6.0.0",
-				"@npmcli/promise-spawn": "^8.0.0",
-				"node-gyp": "^11.0.0",
-				"proc-log": "^5.0.0",
-				"which": "^5.0.0"
+				"@npmcli/node-gyp": "^5.0.0",
+				"@npmcli/package-json": "^7.0.0",
+				"@npmcli/promise-spawn": "^9.0.0",
+				"node-gyp": "^12.1.0",
+				"proc-log": "^6.0.0",
+				"which": "^6.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
-		"node_modules/npm/node_modules/@pkgjs/parseargs": {
-			"version": "0.11.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"optional": true,
-			"engines": {
-				"node": ">=14"
-			}
-		},
-		"node_modules/npm/node_modules/@sigstore/protobuf-specs": {
-			"version": "0.4.3",
-			"dev": true,
-			"inBundle": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/@sigstore/tuf": {
-			"version": "3.1.1",
+		"node_modules/npm/node_modules/@sigstore/bundle": {
+			"version": "4.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@sigstore/protobuf-specs": "^0.4.1",
-				"tuf-js": "^3.0.1"
+				"@sigstore/protobuf-specs": "^0.5.0"
 			},
 			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/@sigstore/core": {
+			"version": "3.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/@sigstore/protobuf-specs": {
+			"version": "0.5.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"engines": {
 				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/@sigstore/sign": {
+			"version": "4.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@sigstore/bundle": "^4.0.0",
+				"@sigstore/core": "^3.1.0",
+				"@sigstore/protobuf-specs": "^0.5.0",
+				"make-fetch-happen": "^15.0.3",
+				"proc-log": "^6.1.0",
+				"promise-retry": "^2.0.1"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/@sigstore/tuf": {
+			"version": "4.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@sigstore/protobuf-specs": "^0.5.0",
+				"tuf-js": "^4.1.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/@sigstore/verify": {
+			"version": "3.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@sigstore/bundle": "^4.0.0",
+				"@sigstore/core": "^3.1.0",
+				"@sigstore/protobuf-specs": "^0.5.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/@tufjs/canonical-json": {
@@ -10758,17 +10837,30 @@
 				"node": "^16.14.0 || >=18.0.0"
 			}
 		},
+		"node_modules/npm/node_modules/@tufjs/models": {
+			"version": "4.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"@tufjs/canonical-json": "2.0.0",
+				"minimatch": "^10.1.1"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
 		"node_modules/npm/node_modules/abbrev": {
-			"version": "3.0.1",
+			"version": "4.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/agent-base": {
-			"version": "7.1.3",
+			"version": "7.1.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -10785,20 +10877,8 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/npm/node_modules/ansi-styles": {
-			"version": "6.2.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
 		"node_modules/npm/node_modules/aproba": {
-			"version": "2.0.0",
+			"version": "2.1.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC"
@@ -10809,124 +10889,58 @@
 			"inBundle": true,
 			"license": "MIT"
 		},
-		"node_modules/npm/node_modules/balanced-match": {
-			"version": "1.0.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
-		},
 		"node_modules/npm/node_modules/bin-links": {
-			"version": "5.0.0",
+			"version": "6.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"cmd-shim": "^7.0.0",
-				"npm-normalize-package-bin": "^4.0.0",
-				"proc-log": "^5.0.0",
-				"read-cmd-shim": "^5.0.0",
-				"write-file-atomic": "^6.0.0"
+				"cmd-shim": "^8.0.0",
+				"npm-normalize-package-bin": "^5.0.0",
+				"proc-log": "^6.0.0",
+				"read-cmd-shim": "^6.0.0",
+				"write-file-atomic": "^7.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/binary-extensions": {
-			"version": "2.3.0",
+			"version": "3.1.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=8"
+				"node": ">=18.20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/npm/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
 		"node_modules/npm/node_modules/cacache": {
-			"version": "19.0.1",
+			"version": "20.0.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/fs": "^4.0.0",
+				"@npmcli/fs": "^5.0.0",
 				"fs-minipass": "^3.0.0",
-				"glob": "^10.2.2",
-				"lru-cache": "^10.0.1",
+				"glob": "^13.0.0",
+				"lru-cache": "^11.1.0",
 				"minipass": "^7.0.3",
 				"minipass-collect": "^2.0.1",
 				"minipass-flush": "^1.0.5",
 				"minipass-pipeline": "^1.2.4",
 				"p-map": "^7.0.2",
-				"ssri": "^12.0.0",
-				"tar": "^7.4.3",
-				"unique-filename": "^4.0.0"
+				"ssri": "^13.0.0",
+				"unique-filename": "^5.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/cacache/node_modules/chownr": {
-			"version": "3.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/npm/node_modules/cacache/node_modules/mkdirp": {
-			"version": "3.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"bin": {
-				"mkdirp": "dist/cjs/src/bin.js"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/npm/node_modules/cacache/node_modules/tar": {
-			"version": "7.4.3",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"@isaacs/fs-minipass": "^4.0.0",
-				"chownr": "^3.0.0",
-				"minipass": "^7.1.2",
-				"minizlib": "^3.0.1",
-				"mkdirp": "^3.0.1",
-				"yallist": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/npm/node_modules/cacache/node_modules/yallist": {
-			"version": "5.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/chalk": {
-			"version": "5.4.1",
+			"version": "5.6.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -10938,16 +10952,16 @@
 			}
 		},
 		"node_modules/npm/node_modules/chownr": {
-			"version": "2.0.0",
+			"version": "3.0.0",
 			"dev": true,
 			"inBundle": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"engines": {
-				"node": ">=10"
+				"node": ">=18"
 			}
 		},
 		"node_modules/npm/node_modules/ci-info": {
-			"version": "4.2.0",
+			"version": "4.3.1",
 			"dev": true,
 			"funding": [
 				{
@@ -10962,15 +10976,15 @@
 			}
 		},
 		"node_modules/npm/node_modules/cidr-regex": {
-			"version": "4.1.3",
+			"version": "5.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"ip-regex": "^5.0.0"
+				"ip-regex": "5.0.0"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=20"
 			}
 		},
 		"node_modules/npm/node_modules/cli-columns": {
@@ -10987,65 +11001,21 @@
 			}
 		},
 		"node_modules/npm/node_modules/cmd-shim": {
-			"version": "7.0.0",
+			"version": "8.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
-		},
-		"node_modules/npm/node_modules/color-convert": {
-			"version": "2.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-name": "~1.1.4"
-			},
-			"engines": {
-				"node": ">=7.0.0"
-			}
-		},
-		"node_modules/npm/node_modules/color-name": {
-			"version": "1.1.4",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/common-ancestor-path": {
-			"version": "1.0.1",
+			"version": "2.0.0",
 			"dev": true,
 			"inBundle": true,
-			"license": "ISC"
-		},
-		"node_modules/npm/node_modules/cross-spawn": {
-			"version": "7.0.6",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"path-key": "^3.1.0",
-				"shebang-command": "^2.0.0",
-				"which": "^2.0.1"
-			},
+			"license": "BlueOak-1.0.0",
 			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/npm/node_modules/cross-spawn/node_modules/which": {
-			"version": "2.0.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"isexe": "^2.0.0"
-			},
-			"bin": {
-				"node-which": "bin/node-which"
-			},
-			"engines": {
-				"node": ">= 8"
+				"node": ">= 18"
 			}
 		},
 		"node_modules/npm/node_modules/cssesc": {
@@ -11061,7 +11031,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/debug": {
-			"version": "4.4.1",
+			"version": "4.4.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -11078,19 +11048,13 @@
 			}
 		},
 		"node_modules/npm/node_modules/diff": {
-			"version": "5.2.0",
+			"version": "8.0.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.3.1"
 			}
-		},
-		"node_modules/npm/node_modules/eastasianwidth": {
-			"version": "0.2.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/emoji-regex": {
 			"version": "8.0.0",
@@ -11124,7 +11088,7 @@
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/exponential-backoff": {
-			"version": "3.1.2",
+			"version": "3.1.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "Apache-2.0"
@@ -11136,22 +11100,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4.9.1"
-			}
-		},
-		"node_modules/npm/node_modules/foreground-child": {
-			"version": "3.3.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"cross-spawn": "^7.0.6",
-				"signal-exit": "^4.0.1"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/npm/node_modules/fs-minipass": {
@@ -11167,20 +11115,17 @@
 			}
 		},
 		"node_modules/npm/node_modules/glob": {
-			"version": "10.4.5",
+			"version": "13.0.0",
 			"dev": true,
 			"inBundle": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"foreground-child": "^3.1.0",
-				"jackspeak": "^3.1.2",
-				"minimatch": "^9.0.4",
+				"minimatch": "^10.1.1",
 				"minipass": "^7.1.2",
-				"package-json-from-dist": "^1.0.0",
-				"path-scurry": "^1.11.1"
+				"path-scurry": "^2.0.0"
 			},
-			"bin": {
-				"glob": "dist/esm/bin.mjs"
+			"engines": {
+				"node": "20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
@@ -11193,15 +11138,15 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/hosted-git-info": {
-			"version": "8.1.0",
+			"version": "9.0.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"lru-cache": "^10.0.1"
+				"lru-cache": "^11.1.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/http-cache-semantics": {
@@ -11250,15 +11195,15 @@
 			}
 		},
 		"node_modules/npm/node_modules/ignore-walk": {
-			"version": "7.0.0",
+			"version": "8.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"minimatch": "^9.0.0"
+				"minimatch": "^10.0.3"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/imurmurhash": {
@@ -11271,41 +11216,37 @@
 			}
 		},
 		"node_modules/npm/node_modules/ini": {
-			"version": "5.0.0",
+			"version": "6.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/init-package-json": {
-			"version": "7.0.2",
+			"version": "8.2.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/package-json": "^6.0.0",
-				"npm-package-arg": "^12.0.0",
-				"promzard": "^2.0.0",
-				"read": "^4.0.0",
-				"semver": "^7.3.5",
+				"@npmcli/package-json": "^7.0.0",
+				"npm-package-arg": "^13.0.0",
+				"promzard": "^3.0.1",
+				"read": "^5.0.1",
+				"semver": "^7.7.2",
 				"validate-npm-package-license": "^3.0.4",
-				"validate-npm-package-name": "^6.0.0"
+				"validate-npm-package-name": "^7.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/ip-address": {
-			"version": "9.0.5",
+			"version": "10.1.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"dependencies": {
-				"jsbn": "1.1.0",
-				"sprintf-js": "^1.1.3"
-			},
 			"engines": {
 				"node": ">= 12"
 			}
@@ -11323,15 +11264,15 @@
 			}
 		},
 		"node_modules/npm/node_modules/is-cidr": {
-			"version": "5.1.1",
+			"version": "6.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"cidr-regex": "^4.1.1"
+				"cidr-regex": "5.0.1"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=20"
 			}
 		},
 		"node_modules/npm/node_modules/is-fullwidth-code-point": {
@@ -11344,39 +11285,21 @@
 			}
 		},
 		"node_modules/npm/node_modules/isexe": {
-			"version": "2.0.0",
+			"version": "3.1.1",
 			"dev": true,
 			"inBundle": true,
-			"license": "ISC"
-		},
-		"node_modules/npm/node_modules/jackspeak": {
-			"version": "3.4.3",
-			"dev": true,
-			"inBundle": true,
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"@isaacs/cliui": "^8.0.2"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			},
-			"optionalDependencies": {
-				"@pkgjs/parseargs": "^0.11.0"
+			"license": "ISC",
+			"engines": {
+				"node": ">=16"
 			}
 		},
-		"node_modules/npm/node_modules/jsbn": {
-			"version": "1.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
-		},
 		"node_modules/npm/node_modules/json-parse-even-better-errors": {
-			"version": "4.0.0",
+			"version": "5.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/json-stringify-nice": {
@@ -11410,218 +11333,201 @@
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/libnpmaccess": {
-			"version": "9.0.0",
+			"version": "10.0.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"npm-package-arg": "^12.0.0",
-				"npm-registry-fetch": "^18.0.1"
+				"npm-package-arg": "^13.0.0",
+				"npm-registry-fetch": "^19.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmdiff": {
-			"version": "7.0.1",
+			"version": "8.0.13",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^8.0.1",
-				"@npmcli/installed-package-contents": "^3.0.0",
-				"binary-extensions": "^2.3.0",
-				"diff": "^5.1.0",
-				"minimatch": "^9.0.4",
-				"npm-package-arg": "^12.0.0",
-				"pacote": "^19.0.0",
-				"tar": "^6.2.1"
+				"@npmcli/arborist": "^9.1.10",
+				"@npmcli/installed-package-contents": "^4.0.0",
+				"binary-extensions": "^3.0.0",
+				"diff": "^8.0.2",
+				"minimatch": "^10.0.3",
+				"npm-package-arg": "^13.0.0",
+				"pacote": "^21.0.2",
+				"tar": "^7.5.1"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmexec": {
-			"version": "9.0.1",
+			"version": "10.1.12",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^8.0.1",
-				"@npmcli/run-script": "^9.0.1",
+				"@npmcli/arborist": "^9.1.10",
+				"@npmcli/package-json": "^7.0.0",
+				"@npmcli/run-script": "^10.0.0",
 				"ci-info": "^4.0.0",
-				"npm-package-arg": "^12.0.0",
-				"pacote": "^19.0.0",
-				"proc-log": "^5.0.0",
-				"read": "^4.0.0",
-				"read-package-json-fast": "^4.0.0",
+				"npm-package-arg": "^13.0.0",
+				"pacote": "^21.0.2",
+				"proc-log": "^6.0.0",
+				"promise-retry": "^2.0.1",
+				"read": "^5.0.1",
 				"semver": "^7.3.7",
-				"walk-up-path": "^3.0.1"
+				"signal-exit": "^4.1.0",
+				"walk-up-path": "^4.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmfund": {
-			"version": "6.0.1",
+			"version": "7.0.13",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^8.0.1"
+				"@npmcli/arborist": "^9.1.10"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/libnpmhook": {
-			"version": "11.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"aproba": "^2.0.0",
-				"npm-registry-fetch": "^18.0.1"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmorg": {
-			"version": "7.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"aproba": "^2.0.0",
-				"npm-registry-fetch": "^18.0.1"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/libnpmpack": {
 			"version": "8.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^8.0.1",
-				"@npmcli/run-script": "^9.0.1",
-				"npm-package-arg": "^12.0.0",
-				"pacote": "^19.0.0"
+				"aproba": "^2.0.0",
+				"npm-registry-fetch": "^19.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmpack": {
+			"version": "9.0.13",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/arborist": "^9.1.10",
+				"@npmcli/run-script": "^10.0.0",
+				"npm-package-arg": "^13.0.0",
+				"pacote": "^21.0.2"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmpublish": {
-			"version": "10.0.1",
+			"version": "11.1.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
+				"@npmcli/package-json": "^7.0.0",
 				"ci-info": "^4.0.0",
-				"normalize-package-data": "^7.0.0",
-				"npm-package-arg": "^12.0.0",
-				"npm-registry-fetch": "^18.0.1",
-				"proc-log": "^5.0.0",
+				"npm-package-arg": "^13.0.0",
+				"npm-registry-fetch": "^19.0.0",
+				"proc-log": "^6.0.0",
 				"semver": "^7.3.7",
-				"sigstore": "^3.0.0",
-				"ssri": "^12.0.0"
+				"sigstore": "^4.0.0",
+				"ssri": "^13.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmsearch": {
-			"version": "8.0.0",
+			"version": "9.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"npm-registry-fetch": "^18.0.1"
+				"npm-registry-fetch": "^19.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmteam": {
-			"version": "7.0.0",
+			"version": "8.0.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"aproba": "^2.0.0",
-				"npm-registry-fetch": "^18.0.1"
+				"npm-registry-fetch": "^19.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmversion": {
-			"version": "7.0.0",
+			"version": "8.0.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/git": "^6.0.1",
-				"@npmcli/run-script": "^9.0.1",
-				"json-parse-even-better-errors": "^4.0.0",
-				"proc-log": "^5.0.0",
+				"@npmcli/git": "^7.0.0",
+				"@npmcli/run-script": "^10.0.0",
+				"json-parse-even-better-errors": "^5.0.0",
+				"proc-log": "^6.0.0",
 				"semver": "^7.3.7"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/lru-cache": {
-			"version": "10.4.3",
+			"version": "11.2.4",
 			"dev": true,
 			"inBundle": true,
-			"license": "ISC"
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
 		},
 		"node_modules/npm/node_modules/make-fetch-happen": {
-			"version": "14.0.3",
+			"version": "15.0.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/agent": "^3.0.0",
-				"cacache": "^19.0.1",
+				"@npmcli/agent": "^4.0.0",
+				"cacache": "^20.0.1",
 				"http-cache-semantics": "^4.1.1",
 				"minipass": "^7.0.2",
-				"minipass-fetch": "^4.0.0",
+				"minipass-fetch": "^5.0.0",
 				"minipass-flush": "^1.0.5",
 				"minipass-pipeline": "^1.2.4",
 				"negotiator": "^1.0.0",
-				"proc-log": "^5.0.0",
+				"proc-log": "^6.0.0",
 				"promise-retry": "^2.0.1",
-				"ssri": "^12.0.0"
+				"ssri": "^13.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/make-fetch-happen/node_modules/negotiator": {
-			"version": "1.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/minimatch": {
-			"version": "9.0.5",
+			"version": "10.1.1",
 			"dev": true,
 			"inBundle": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"@isaacs/brace-expansion": "^5.0.0"
 			},
 			"engines": {
-				"node": ">=16 || 14 >=14.17"
+				"node": "20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
@@ -11649,7 +11555,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/minipass-fetch": {
-			"version": "4.0.1",
+			"version": "5.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -11659,7 +11565,7 @@
 				"minizlib": "^3.0.1"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			},
 			"optionalDependencies": {
 				"encoding": "^0.1.13"
@@ -11738,7 +11644,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/minizlib": {
-			"version": "3.0.2",
+			"version": "3.1.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -11749,18 +11655,6 @@
 				"node": ">= 18"
 			}
 		},
-		"node_modules/npm/node_modules/mkdirp": {
-			"version": "1.0.4",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"bin": {
-				"mkdirp": "bin/cmd.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/npm/node_modules/ms": {
 			"version": "2.1.3",
 			"dev": true,
@@ -11768,16 +11662,25 @@
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/mute-stream": {
-			"version": "2.0.0",
+			"version": "3.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/negotiator": {
+			"version": "1.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
 			}
 		},
 		"node_modules/npm/node_modules/node-gyp": {
-			"version": "11.2.0",
+			"version": "12.1.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -11785,123 +11688,59 @@
 				"env-paths": "^2.2.0",
 				"exponential-backoff": "^3.1.1",
 				"graceful-fs": "^4.2.6",
-				"make-fetch-happen": "^14.0.3",
-				"nopt": "^8.0.0",
-				"proc-log": "^5.0.0",
+				"make-fetch-happen": "^15.0.0",
+				"nopt": "^9.0.0",
+				"proc-log": "^6.0.0",
 				"semver": "^7.3.5",
-				"tar": "^7.4.3",
+				"tar": "^7.5.2",
 				"tinyglobby": "^0.2.12",
-				"which": "^5.0.0"
+				"which": "^6.0.0"
 			},
 			"bin": {
 				"node-gyp": "bin/node-gyp.js"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/node-gyp/node_modules/chownr": {
-			"version": "3.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/npm/node_modules/node-gyp/node_modules/mkdirp": {
-			"version": "3.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"bin": {
-				"mkdirp": "dist/cjs/src/bin.js"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/npm/node_modules/node-gyp/node_modules/tar": {
-			"version": "7.4.3",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"@isaacs/fs-minipass": "^4.0.0",
-				"chownr": "^3.0.0",
-				"minipass": "^7.1.2",
-				"minizlib": "^3.0.1",
-				"mkdirp": "^3.0.1",
-				"yallist": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/npm/node_modules/node-gyp/node_modules/yallist": {
-			"version": "5.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/nopt": {
-			"version": "8.1.0",
+			"version": "9.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"abbrev": "^3.0.0"
+				"abbrev": "^4.0.0"
 			},
 			"bin": {
 				"nopt": "bin/nopt.js"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/normalize-package-data": {
-			"version": "7.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"hosted-git-info": "^8.0.0",
-				"semver": "^7.3.5",
-				"validate-npm-package-license": "^3.0.4"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-audit-report": {
-			"version": "6.0.0",
+			"version": "7.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-bundled": {
-			"version": "4.0.0",
+			"version": "5.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"npm-normalize-package-bin": "^4.0.0"
+				"npm-normalize-package-bin": "^5.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-install-checks": {
-			"version": "7.1.1",
+			"version": "8.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "BSD-2-Clause",
@@ -11909,103 +11748,104 @@
 				"semver": "^7.1.1"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-normalize-package-bin": {
-			"version": "4.0.0",
+			"version": "5.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-package-arg": {
-			"version": "12.0.2",
+			"version": "13.0.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"hosted-git-info": "^8.0.0",
-				"proc-log": "^5.0.0",
+				"hosted-git-info": "^9.0.0",
+				"proc-log": "^6.0.0",
 				"semver": "^7.3.5",
-				"validate-npm-package-name": "^6.0.0"
+				"validate-npm-package-name": "^7.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-packlist": {
-			"version": "9.0.0",
+			"version": "10.0.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"ignore-walk": "^7.0.0"
+				"ignore-walk": "^8.0.0",
+				"proc-log": "^6.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-pick-manifest": {
-			"version": "10.0.0",
+			"version": "11.0.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"npm-install-checks": "^7.1.0",
-				"npm-normalize-package-bin": "^4.0.0",
-				"npm-package-arg": "^12.0.0",
+				"npm-install-checks": "^8.0.0",
+				"npm-normalize-package-bin": "^5.0.0",
+				"npm-package-arg": "^13.0.0",
 				"semver": "^7.3.5"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-profile": {
-			"version": "11.0.1",
+			"version": "12.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"npm-registry-fetch": "^18.0.0",
-				"proc-log": "^5.0.0"
+				"npm-registry-fetch": "^19.0.0",
+				"proc-log": "^6.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-registry-fetch": {
-			"version": "18.0.2",
+			"version": "19.1.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/redact": "^3.0.0",
+				"@npmcli/redact": "^4.0.0",
 				"jsonparse": "^1.3.1",
-				"make-fetch-happen": "^14.0.0",
+				"make-fetch-happen": "^15.0.0",
 				"minipass": "^7.0.2",
-				"minipass-fetch": "^4.0.0",
+				"minipass-fetch": "^5.0.0",
 				"minizlib": "^3.0.1",
-				"npm-package-arg": "^12.0.0",
-				"proc-log": "^5.0.0"
+				"npm-package-arg": "^13.0.0",
+				"proc-log": "^6.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-user-validate": {
-			"version": "3.0.0",
+			"version": "4.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "BSD-2-Clause",
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/p-map": {
-			"version": "7.0.3",
+			"version": "7.0.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -12016,84 +11856,69 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/npm/node_modules/package-json-from-dist": {
-			"version": "1.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "BlueOak-1.0.0"
-		},
 		"node_modules/npm/node_modules/pacote": {
-			"version": "19.0.1",
+			"version": "21.0.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/git": "^6.0.0",
-				"@npmcli/installed-package-contents": "^3.0.0",
-				"@npmcli/package-json": "^6.0.0",
-				"@npmcli/promise-spawn": "^8.0.0",
-				"@npmcli/run-script": "^9.0.0",
-				"cacache": "^19.0.0",
+				"@npmcli/git": "^7.0.0",
+				"@npmcli/installed-package-contents": "^4.0.0",
+				"@npmcli/package-json": "^7.0.0",
+				"@npmcli/promise-spawn": "^9.0.0",
+				"@npmcli/run-script": "^10.0.0",
+				"cacache": "^20.0.0",
 				"fs-minipass": "^3.0.0",
 				"minipass": "^7.0.2",
-				"npm-package-arg": "^12.0.0",
-				"npm-packlist": "^9.0.0",
-				"npm-pick-manifest": "^10.0.0",
-				"npm-registry-fetch": "^18.0.0",
-				"proc-log": "^5.0.0",
+				"npm-package-arg": "^13.0.0",
+				"npm-packlist": "^10.0.1",
+				"npm-pick-manifest": "^11.0.1",
+				"npm-registry-fetch": "^19.0.0",
+				"proc-log": "^6.0.0",
 				"promise-retry": "^2.0.1",
-				"sigstore": "^3.0.0",
-				"ssri": "^12.0.0",
-				"tar": "^6.1.11"
+				"sigstore": "^4.0.0",
+				"ssri": "^13.0.0",
+				"tar": "^7.4.3"
 			},
 			"bin": {
 				"pacote": "bin/index.js"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/parse-conflict-json": {
-			"version": "4.0.0",
+			"version": "5.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"json-parse-even-better-errors": "^4.0.0",
+				"json-parse-even-better-errors": "^5.0.0",
 				"just-diff": "^6.0.0",
 				"just-diff-apply": "^5.2.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/path-key": {
-			"version": "3.1.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/path-scurry": {
-			"version": "1.11.1",
+			"version": "2.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"lru-cache": "^10.2.0",
-				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
 			},
 			"engines": {
-				"node": ">=16 || 14 >=14.18"
+				"node": "20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/npm/node_modules/postcss-selector-parser": {
-			"version": "7.1.0",
+			"version": "7.1.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -12106,21 +11931,21 @@
 			}
 		},
 		"node_modules/npm/node_modules/proc-log": {
-			"version": "5.0.0",
+			"version": "6.1.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/proggy": {
-			"version": "3.0.0",
+			"version": "4.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/promise-all-reject-late": {
@@ -12155,15 +11980,15 @@
 			}
 		},
 		"node_modules/npm/node_modules/promzard": {
-			"version": "2.0.0",
+			"version": "3.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"read": "^4.0.0"
+				"read": "^5.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/qrcode-terminal": {
@@ -12175,37 +12000,24 @@
 			}
 		},
 		"node_modules/npm/node_modules/read": {
-			"version": "4.1.0",
+			"version": "5.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"mute-stream": "^2.0.0"
+				"mute-stream": "^3.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/read-cmd-shim": {
-			"version": "5.0.0",
+			"version": "6.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/read-package-json-fast": {
-			"version": "4.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"json-parse-even-better-errors": "^4.0.0",
-				"npm-normalize-package-bin": "^4.0.0"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/retry": {
@@ -12225,7 +12037,7 @@
 			"optional": true
 		},
 		"node_modules/npm/node_modules/semver": {
-			"version": "7.7.2",
+			"version": "7.7.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -12234,27 +12046,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/npm/node_modules/shebang-command": {
-			"version": "2.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"shebang-regex": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/npm/node_modules/shebang-regex": {
-			"version": "3.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/npm/node_modules/signal-exit": {
@@ -12270,72 +12061,20 @@
 			}
 		},
 		"node_modules/npm/node_modules/sigstore": {
-			"version": "3.1.0",
+			"version": "4.1.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@sigstore/bundle": "^3.1.0",
-				"@sigstore/core": "^2.0.0",
-				"@sigstore/protobuf-specs": "^0.4.0",
-				"@sigstore/sign": "^3.1.0",
-				"@sigstore/tuf": "^3.1.0",
-				"@sigstore/verify": "^2.1.0"
+				"@sigstore/bundle": "^4.0.0",
+				"@sigstore/core": "^3.1.0",
+				"@sigstore/protobuf-specs": "^0.5.0",
+				"@sigstore/sign": "^4.1.0",
+				"@sigstore/tuf": "^4.0.1",
+				"@sigstore/verify": "^3.1.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/sigstore/node_modules/@sigstore/bundle": {
-			"version": "3.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@sigstore/protobuf-specs": "^0.4.0"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/sigstore/node_modules/@sigstore/core": {
-			"version": "2.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/sigstore/node_modules/@sigstore/sign": {
-			"version": "3.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@sigstore/bundle": "^3.1.0",
-				"@sigstore/core": "^2.0.0",
-				"@sigstore/protobuf-specs": "^0.4.0",
-				"make-fetch-happen": "^14.0.2",
-				"proc-log": "^5.0.0",
-				"promise-retry": "^2.0.1"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/sigstore/node_modules/@sigstore/verify": {
-			"version": "2.1.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@sigstore/bundle": "^3.1.0",
-				"@sigstore/core": "^2.0.0",
-				"@sigstore/protobuf-specs": "^0.4.1"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/smart-buffer": {
@@ -12349,12 +12088,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/socks": {
-			"version": "2.8.5",
+			"version": "2.8.7",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"ip-address": "^9.0.5",
+				"ip-address": "^10.0.1",
 				"smart-buffer": "^4.2.0"
 			},
 			"engines": {
@@ -12413,19 +12152,13 @@
 			}
 		},
 		"node_modules/npm/node_modules/spdx-license-ids": {
-			"version": "3.0.21",
+			"version": "3.0.22",
 			"dev": true,
 			"inBundle": true,
 			"license": "CC0-1.0"
 		},
-		"node_modules/npm/node_modules/sprintf-js": {
-			"version": "1.1.3",
-			"dev": true,
-			"inBundle": true,
-			"license": "BSD-3-Clause"
-		},
 		"node_modules/npm/node_modules/ssri": {
-			"version": "12.0.0",
+			"version": "13.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -12433,25 +12166,10 @@
 				"minipass": "^7.0.3"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/string-width": {
-			"version": "4.2.3",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/npm/node_modules/string-width-cjs": {
-			"name": "string-width",
 			"version": "4.2.3",
 			"dev": true,
 			"inBundle": true,
@@ -12477,104 +12195,41 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/npm/node_modules/strip-ansi-cjs": {
-			"name": "strip-ansi",
-			"version": "6.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/npm/node_modules/supports-color": {
-			"version": "9.4.0",
+			"version": "10.2.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
 		"node_modules/npm/node_modules/tar": {
-			"version": "6.2.1",
+			"version": "7.5.4",
 			"dev": true,
 			"inBundle": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"chownr": "^2.0.0",
-				"fs-minipass": "^2.0.0",
-				"minipass": "^5.0.0",
-				"minizlib": "^2.1.1",
-				"mkdirp": "^1.0.3",
-				"yallist": "^4.0.0"
+				"@isaacs/fs-minipass": "^4.0.0",
+				"chownr": "^3.0.0",
+				"minipass": "^7.1.2",
+				"minizlib": "^3.1.0",
+				"yallist": "^5.0.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=18"
 			}
 		},
-		"node_modules/npm/node_modules/tar/node_modules/fs-minipass": {
-			"version": "2.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^3.0.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/npm/node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
-			"version": "3.3.6",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/npm/node_modules/tar/node_modules/minipass": {
+		"node_modules/npm/node_modules/tar/node_modules/yallist": {
 			"version": "5.0.0",
 			"dev": true,
 			"inBundle": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/npm/node_modules/tar/node_modules/minizlib": {
-			"version": "2.1.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"minipass": "^3.0.0",
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/npm/node_modules/tar/node_modules/minizlib/node_modules/minipass": {
-			"version": "3.3.6",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
+				"node": ">=18"
 			}
 		},
 		"node_modules/npm/node_modules/text-table": {
@@ -12584,19 +12239,19 @@
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/tiny-relative-date": {
-			"version": "1.3.0",
+			"version": "2.0.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/tinyglobby": {
-			"version": "0.2.14",
+			"version": "0.2.15",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"fdir": "^6.4.4",
-				"picomatch": "^4.0.2"
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.3"
 			},
 			"engines": {
 				"node": ">=12.0.0"
@@ -12606,10 +12261,13 @@
 			}
 		},
 		"node_modules/npm/node_modules/tinyglobby/node_modules/fdir": {
-			"version": "6.4.6",
+			"version": "6.5.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
 			"peerDependencies": {
 				"picomatch": "^3 || ^4"
 			},
@@ -12620,7 +12278,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
-			"version": "4.0.2",
+			"version": "4.0.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -12642,46 +12300,33 @@
 			}
 		},
 		"node_modules/npm/node_modules/tuf-js": {
-			"version": "3.0.1",
+			"version": "4.1.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"@tufjs/models": "3.0.1",
-				"debug": "^4.3.6",
-				"make-fetch-happen": "^14.0.1"
+				"@tufjs/models": "4.1.0",
+				"debug": "^4.4.3",
+				"make-fetch-happen": "^15.0.1"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/tuf-js/node_modules/@tufjs/models": {
-			"version": "3.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"@tufjs/canonical-json": "2.0.0",
-				"minimatch": "^9.0.5"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/unique-filename": {
-			"version": "4.0.0",
+			"version": "5.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"unique-slug": "^5.0.0"
+				"unique-slug": "^6.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/unique-slug": {
-			"version": "5.0.0",
+			"version": "6.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -12689,7 +12334,7 @@
 				"imurmurhash": "^0.1.4"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/util-deprecate": {
@@ -12719,22 +12364,25 @@
 			}
 		},
 		"node_modules/npm/node_modules/validate-npm-package-name": {
-			"version": "6.0.1",
+			"version": "7.0.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/walk-up-path": {
-			"version": "3.0.1",
+			"version": "4.0.0",
 			"dev": true,
 			"inBundle": true,
-			"license": "ISC"
+			"license": "ISC",
+			"engines": {
+				"node": "20 || >=22"
+			}
 		},
 		"node_modules/npm/node_modules/which": {
-			"version": "5.0.0",
+			"version": "6.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -12745,120 +12393,11 @@
 				"node-which": "bin/which.js"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/which/node_modules/isexe": {
-			"version": "3.1.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=16"
-			}
-		},
-		"node_modules/npm/node_modules/wrap-ansi": {
-			"version": "8.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^6.1.0",
-				"string-width": "^5.0.1",
-				"strip-ansi": "^7.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
-		},
-		"node_modules/npm/node_modules/wrap-ansi-cjs": {
-			"name": "wrap-ansi",
-			"version": "7.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.0.0",
-				"string-width": "^4.1.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
-		},
-		"node_modules/npm/node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
-			"version": "6.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
-			}
-		},
-		"node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {
-			"version": "9.2.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
-		},
-		"node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
-			"version": "5.1.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"eastasianwidth": "^0.2.0",
-				"emoji-regex": "^9.2.2",
-				"strip-ansi": "^7.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
-			"version": "7.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/write-file-atomic": {
-			"version": "6.0.0",
+			"version": "7.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -12867,7 +12406,7 @@
 				"signal-exit": "^4.0.1"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/yallist": {
@@ -14352,18 +13891,18 @@
 			"license": "MIT"
 		},
 		"node_modules/semantic-release": {
-			"version": "24.2.9",
-			"resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-24.2.9.tgz",
-			"integrity": "sha512-phCkJ6pjDi9ANdhuF5ElS10GGdAKY6R1Pvt9lT3SFhOwM4T7QZE7MLpBDbNruUx/Q3gFD92/UOFringGipRqZA==",
+			"version": "25.0.2",
+			"resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.2.tgz",
+			"integrity": "sha512-6qGjWccl5yoyugHt3jTgztJ9Y0JVzyH8/Voc/D8PlLat9pwxQYXz7W1Dpnq5h0/G5GCYGUaDSlYcyk3AMh5A6g==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@semantic-release/commit-analyzer": "^13.0.0-beta.1",
+				"@semantic-release/commit-analyzer": "^13.0.1",
 				"@semantic-release/error": "^4.0.0",
-				"@semantic-release/github": "^11.0.0",
-				"@semantic-release/npm": "^12.0.2",
-				"@semantic-release/release-notes-generator": "^14.0.0-beta.1",
+				"@semantic-release/github": "^12.0.0",
+				"@semantic-release/npm": "^13.1.1",
+				"@semantic-release/release-notes-generator": "^14.1.0",
 				"aggregate-error": "^5.0.0",
 				"cosmiconfig": "^9.0.0",
 				"debug": "^4.0.0",
@@ -14374,7 +13913,7 @@
 				"get-stream": "^6.0.0",
 				"git-log-parser": "^1.2.0",
 				"hook-std": "^4.0.0",
-				"hosted-git-info": "^8.0.0",
+				"hosted-git-info": "^9.0.0",
 				"import-from-esm": "^2.0.0",
 				"lodash-es": "^4.17.21",
 				"marked": "^15.0.0",
@@ -14382,18 +13921,18 @@
 				"micromatch": "^4.0.2",
 				"p-each-series": "^3.0.0",
 				"p-reduce": "^3.0.0",
-				"read-package-up": "^11.0.0",
+				"read-package-up": "^12.0.0",
 				"resolve-from": "^5.0.0",
 				"semver": "^7.3.2",
 				"semver-diff": "^5.0.0",
 				"signale": "^1.2.1",
-				"yargs": "^17.5.1"
+				"yargs": "^18.0.0"
 			},
 			"bin": {
 				"semantic-release": "bin/semantic-release.js"
 			},
 			"engines": {
-				"node": ">=20.8.1"
+				"node": "^22.14.0 || >= 24.10.0"
 			}
 		},
 		"node_modules/semantic-release/node_modules/@semantic-release/error": {
@@ -14438,6 +13977,28 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/semantic-release/node_modules/cliui": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+			"integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^7.2.0",
+				"strip-ansi": "^7.1.0",
+				"wrap-ansi": "^9.0.0"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/semantic-release/node_modules/emoji-regex": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+			"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/semantic-release/node_modules/escape-string-regexp": {
 			"version": "5.0.0",
@@ -14532,6 +14093,21 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/semantic-release/node_modules/normalize-package-data": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-8.0.0.tgz",
+			"integrity": "sha512-RWk+PI433eESQ7ounYxIp67CYuVsS1uYSonX3kA6ps/3LWfjVQa/ptEg6Y3T6uAMq1mWpX9PQ+qx+QaHpsc7gQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"hosted-git-info": "^9.0.0",
+				"semver": "^7.3.5",
+				"validate-npm-package-license": "^3.0.4"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
 		"node_modules/semantic-release/node_modules/npm-run-path": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
@@ -14562,6 +14138,37 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/semantic-release/node_modules/parse-json": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+			"integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.26.2",
+				"index-to-position": "^1.1.0",
+				"type-fest": "^4.39.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semantic-release/node_modules/parse-json/node_modules/type-fest": {
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/semantic-release/node_modules/path-key": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
@@ -14570,6 +14177,44 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semantic-release/node_modules/read-package-up": {
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-12.0.0.tgz",
+			"integrity": "sha512-Q5hMVBYur/eQNWDdbF4/Wqqr9Bjvtrw2kjGxxBbKLbx8bVCL8gcArjTy8zDUuLGQicftpMuU0riQNcAsbtOVsw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"find-up-simple": "^1.0.1",
+				"read-pkg": "^10.0.0",
+				"type-fest": "^5.2.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semantic-release/node_modules/read-pkg": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-10.0.0.tgz",
+			"integrity": "sha512-A70UlgfNdKI5NSvTTfHzLQj7NJRpJ4mT5tGafkllJ4wh71oYuGm/pzphHcmW4s35iox56KSK721AihodoXSc/A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/normalize-package-data": "^2.4.4",
+				"normalize-package-data": "^8.0.0",
+				"parse-json": "^8.3.0",
+				"type-fest": "^5.2.0",
+				"unicorn-magic": "^0.3.0"
+			},
+			"engines": {
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -14588,6 +14233,24 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/semantic-release/node_modules/string-width": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/semantic-release/node_modules/strip-final-newline": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
@@ -14596,6 +14259,22 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semantic-release/node_modules/type-fest": {
+			"version": "5.4.2",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.4.2.tgz",
+			"integrity": "sha512-FLEenlVYf7Zcd34ISMLo3ZzRE1gRjY1nMDTp+bQRBiPsaKyIW8K3Zr99ioHDUgA9OGuGGJPyYpNcffGmBhJfGg==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"dependencies": {
+				"tagged-tag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -14612,6 +14291,34 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semantic-release/node_modules/yargs": {
+			"version": "18.0.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+			"integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^9.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"string-width": "^7.2.0",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^22.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=23"
+			}
+		},
+		"node_modules/semantic-release/node_modules/yargs-parser": {
+			"version": "22.0.0",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+			"integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=23"
 			}
 		},
 		"node_modules/semver": {
@@ -15382,6 +15089,19 @@
 				"node": ">=12.17"
 			}
 		},
+		"node_modules/tagged-tag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+			"integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/tar-fs": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
@@ -15695,6 +15415,16 @@
 				"node": ">=0.6.x"
 			}
 		},
+		"node_modules/tunnel": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+			"integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+			}
+		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -15937,6 +15667,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/undici": {
+			"version": "7.19.2",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.19.2.tgz",
+			"integrity": "sha512-4VQSpGEGsWzk0VYxyB/wVX/Q7qf9t5znLRgs0dzszr9w9Fej/8RVNQ+S20vdXSAyra/bJ7ZQfGv6ZMj7UEbzSg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.18.1"
 			}
 		},
 		"node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
 		"@webcomponents/webcomponentsjs": "^2.5.0",
 		"husky": "^8.0.0",
 		"lint-staged": "^16.2.7",
-		"semantic-release": "^24.0.0",
+		"semantic-release": "^25.0.0",
 		"sinon": "^17.0.0",
 		"web-animations-js": "^2.3.1"
 	}


### PR DESCRIPTION
## Summary

- Upgrade from `semantic-release@24` to `semantic-release@25`
- This brings in `@semantic-release/npm@13` which supports npm trusted publishing via OIDC
- Enables publishing without requiring `NPM_TOKEN` secrets

## Why

The previous release failed because `@semantic-release/npm@12` (bundled with semantic-release v24) doesn't support trusted publishing. It requires an `NPM_TOKEN` env var even when trusted publishing is configured on npm.

`@semantic-release/npm@13` (bundled with semantic-release v25) automatically uses OIDC tokens when:
- No `NPM_TOKEN` is provided
- `id-token: write` permission is enabled (already configured in ci.yml)
- Trusted publisher is configured on npm (already done)

## Related

- Fixes release failure for NEO-803
- Related to NEO-738 (npm trusted publishing setup)