### PR TITLE
fix: support cosmoz-bottom-bar v10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "7.1.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@neovici/cosmoz-bottom-bar": "^7.0.0 || ^8.0.0 || ^9.0.0",
+				"@neovici/cosmoz-bottom-bar": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
 				"@neovici/cosmoz-i18next": "^3.0.0",
 				"@neovici/cosmoz-utils": "^6.0.0",
 				"@pionjs/pion": "^2.0.0",
@@ -1203,9 +1203,9 @@
 			}
 		},
 		"node_modules/@neovici/cfg": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/@neovici/cfg/-/cfg-2.8.0.tgz",
-			"integrity": "sha512-fW8jXsbRFhmZbB3YmVFZss/0lDDWhNimZk03aruj6Fp7O9cakIX5I1+EEqdM7TkHliZNika7bJXTZLhOg3SeEg==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/@neovici/cfg/-/cfg-2.8.1.tgz",
+			"integrity": "sha512-oAr8c6HMUDOJ0PK4UBT31nKEu0pfJsI1rxt7JY6ufVjEKrAH7XTTxxChhP/9NrTQwt7ucUNYbl30S+y4P548bw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -1235,13 +1235,13 @@
 			}
 		},
 		"node_modules/@neovici/cosmoz-bottom-bar": {
-			"version": "9.5.0",
-			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-bottom-bar/-/cosmoz-bottom-bar-9.5.0.tgz",
-			"integrity": "sha512-mGpmJQP8c2yxuIiE4k/wSvLXQWzhC7Q2jZOe+TuAWKQxnbudl6lknN2PTWjAt4qDXCuC6Oz7JRTZIeTabVmxkg==",
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-bottom-bar/-/cosmoz-bottom-bar-10.2.0.tgz",
+			"integrity": "sha512-3x3fs55E5IyOmd0P5AKUgf9sZfAaMApyzEldVuGiuFEOcvOFTHkHnEqLTrY0zZWyOcIC5aJqwexqpaZQAjwHEw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@neovici/cosmoz-collapse": "^1.5.0",
-				"@neovici/cosmoz-dropdown": "^6.0.0",
+				"@neovici/cosmoz-dropdown": "^7.0.0",
 				"@neovici/cosmoz-utils": "^6.13.1",
 				"@pionjs/pion": "^2.5.2",
 				"@polymer/polymer": "^3.3.0",
@@ -1258,9 +1258,9 @@
 			}
 		},
 		"node_modules/@neovici/cosmoz-dropdown": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-dropdown/-/cosmoz-dropdown-6.5.0.tgz",
-			"integrity": "sha512-zHfecK77qERy/lA4W6K1KFVsej67hV1b0s0qMVQGBVL84l+spiCJZjkkC4my3A7dLBvt4BTpxv2wFQ3rNzt/0g==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-dropdown/-/cosmoz-dropdown-7.0.1.tgz",
+			"integrity": "sha512-IX1m8pX4Q1D4TzeBOFqcAFTaM983oYyqV58paEBH7qGo7RLqTuouEtdxPjo53m5HPdKXf9q8lDL9DjYc/guXZA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@floating-ui/dom": "^1.6.12",
@@ -1270,9 +1270,9 @@
 			}
 		},
 		"node_modules/@neovici/cosmoz-i18next": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-i18next/-/cosmoz-i18next-3.5.1.tgz",
-			"integrity": "sha512-KkHiIRKSnyDn8SZ64cUb7dPgjB/2otJarqyfzzlb4H/cqeitdHwfPu49cgzK+qadWv8Cb2pi+wN5/YWowmQQUw==",
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-i18next/-/cosmoz-i18next-3.5.2.tgz",
+			"integrity": "sha512-T+kDuFJLhKGnhe3j9i28CofKTJHFU43XhNL9EKFXsqxpzn82+Dcc7SL6KtyeUnwIm3LaY30di/Qv1GQbGPnC1g==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@polymer/polymer": "^3.3.1",
@@ -1280,9 +1280,9 @@
 			}
 		},
 		"node_modules/@neovici/cosmoz-utils": {
-			"version": "6.17.0",
-			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-utils/-/cosmoz-utils-6.17.0.tgz",
-			"integrity": "sha512-tPf9w3xhe0tR6LaksgjLl4h+ucsIwGCY990zbN24bXUAhmkXXnV2CrNi82W04bH+u4Jxed4VxCMJzhD8RBPaNw==",
+			"version": "6.17.1",
+			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-utils/-/cosmoz-utils-6.17.1.tgz",
+			"integrity": "sha512-6ogiXZzMk/3nfeIqR9521mhDAvk8mhq57h9m7hilIdkJeO7C2XQF/sy/YMU2acbJTMkB2qNNh7nGbX6jjF5bvA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@pionjs/pion": "^2.7.1"
@@ -2662,21 +2662,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/@semantic-release/npm/node_modules/normalize-package-data": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-8.0.0.tgz",
-			"integrity": "sha512-RWk+PI433eESQ7ounYxIp67CYuVsS1uYSonX3kA6ps/3LWfjVQa/ptEg6Y3T6uAMq1mWpX9PQ+qx+QaHpsc7gQ==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"hosted-git-info": "^9.0.0",
-				"semver": "^7.3.5",
-				"validate-npm-package-license": "^3.0.4"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
 		"node_modules/@semantic-release/npm/node_modules/npm-run-path": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
@@ -2694,37 +2679,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/@semantic-release/npm/node_modules/parse-json": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
-			"integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.26.2",
-				"index-to-position": "^1.1.0",
-				"type-fest": "^4.39.1"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@semantic-release/npm/node_modules/parse-json/node_modules/type-fest": {
-			"version": "4.41.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
-			"engines": {
-				"node": ">=16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/@semantic-release/npm/node_modules/path-key": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
@@ -2733,26 +2687,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@semantic-release/npm/node_modules/read-pkg": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-10.0.0.tgz",
-			"integrity": "sha512-A70UlgfNdKI5NSvTTfHzLQj7NJRpJ4mT5tGafkllJ4wh71oYuGm/pzphHcmW4s35iox56KSK721AihodoXSc/A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/normalize-package-data": "^2.4.4",
-				"normalize-package-data": "^8.0.0",
-				"parse-json": "^8.3.0",
-				"type-fest": "^5.2.0",
-				"unicorn-magic": "^0.3.0"
-			},
-			"engines": {
-				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -2779,22 +2713,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@semantic-release/npm/node_modules/type-fest": {
-			"version": "5.4.2",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.4.2.tgz",
-			"integrity": "sha512-FLEenlVYf7Zcd34ISMLo3ZzRE1gRjY1nMDTp+bQRBiPsaKyIW8K3Zr99ioHDUgA9OGuGGJPyYpNcffGmBhJfGg==",
-			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
-			"dependencies": {
-				"tagged-tag": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -2880,6 +2798,26 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/@semantic-release/release-notes-generator/node_modules/hosted-git-info": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+			"integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"lru-cache": "^10.0.1"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@semantic-release/release-notes-generator/node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/@semantic-release/release-notes-generator/node_modules/meow": {
 			"version": "13.2.0",
 			"resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
@@ -2888,6 +2826,90 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/release-notes-generator/node_modules/normalize-package-data": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+			"integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"hosted-git-info": "^7.0.0",
+				"semver": "^7.3.5",
+				"validate-npm-package-license": "^3.0.4"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@semantic-release/release-notes-generator/node_modules/parse-json": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+			"integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.26.2",
+				"index-to-position": "^1.1.0",
+				"type-fest": "^4.39.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/release-notes-generator/node_modules/read-package-up": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-11.0.0.tgz",
+			"integrity": "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"find-up-simple": "^1.0.0",
+				"read-pkg": "^9.0.0",
+				"type-fest": "^4.6.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/release-notes-generator/node_modules/read-pkg": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
+			"integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/normalize-package-data": "^2.4.3",
+				"normalize-package-data": "^6.0.0",
+				"parse-json": "^8.0.0",
+				"type-fest": "^4.6.0",
+				"unicorn-magic": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/release-notes-generator/node_modules/type-fest": {
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=16"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -3224,9 +3246,9 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "25.0.10",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.10.tgz",
-			"integrity": "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==",
+			"version": "25.1.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.1.0.tgz",
+			"integrity": "sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -10252,39 +10274,19 @@
 			}
 		},
 		"node_modules/normalize-package-data": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
-			"integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-8.0.0.tgz",
+			"integrity": "sha512-RWk+PI433eESQ7ounYxIp67CYuVsS1uYSonX3kA6ps/3LWfjVQa/ptEg6Y3T6uAMq1mWpX9PQ+qx+QaHpsc7gQ==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"hosted-git-info": "^7.0.0",
+				"hosted-git-info": "^9.0.0",
 				"semver": "^7.3.5",
 				"validate-npm-package-license": "^3.0.4"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
-		},
-		"node_modules/normalize-package-data/node_modules/hosted-git-info": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
-			"integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"lru-cache": "^10.0.1"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/normalize-package-data/node_modules/lru-cache": {
-			"version": "10.4.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-			"dev": true,
-			"license": "ISC"
 		},
 		"node_modules/normalize-url": {
 			"version": "8.1.1",
@@ -13408,51 +13410,54 @@
 			}
 		},
 		"node_modules/read-package-up": {
-			"version": "11.0.0",
-			"resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-11.0.0.tgz",
-			"integrity": "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==",
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-12.0.0.tgz",
+			"integrity": "sha512-Q5hMVBYur/eQNWDdbF4/Wqqr9Bjvtrw2kjGxxBbKLbx8bVCL8gcArjTy8zDUuLGQicftpMuU0riQNcAsbtOVsw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"find-up-simple": "^1.0.0",
-				"read-pkg": "^9.0.0",
-				"type-fest": "^4.6.0"
+				"find-up-simple": "^1.0.1",
+				"read-pkg": "^10.0.0",
+				"type-fest": "^5.2.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/read-package-up/node_modules/type-fest": {
-			"version": "4.41.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+			"version": "5.4.2",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.4.2.tgz",
+			"integrity": "sha512-FLEenlVYf7Zcd34ISMLo3ZzRE1gRjY1nMDTp+bQRBiPsaKyIW8K3Zr99ioHDUgA9OGuGGJPyYpNcffGmBhJfGg==",
 			"dev": true,
 			"license": "(MIT OR CC0-1.0)",
+			"dependencies": {
+				"tagged-tag": "^1.0.0"
+			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/read-pkg": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
-			"integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-10.0.0.tgz",
+			"integrity": "sha512-A70UlgfNdKI5NSvTTfHzLQj7NJRpJ4mT5tGafkllJ4wh71oYuGm/pzphHcmW4s35iox56KSK721AihodoXSc/A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@types/normalize-package-data": "^2.4.3",
-				"normalize-package-data": "^6.0.0",
-				"parse-json": "^8.0.0",
-				"type-fest": "^4.6.0",
-				"unicorn-magic": "^0.1.0"
+				"@types/normalize-package-data": "^2.4.4",
+				"normalize-package-data": "^8.0.0",
+				"parse-json": "^8.3.0",
+				"type-fest": "^5.2.0",
+				"unicorn-magic": "^0.3.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -13476,7 +13481,7 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/read-pkg/node_modules/type-fest": {
+		"node_modules/read-pkg/node_modules/parse-json/node_modules/type-fest": {
 			"version": "4.41.0",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
 			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
@@ -13484,6 +13489,35 @@
 			"license": "(MIT OR CC0-1.0)",
 			"engines": {
 				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/read-pkg/node_modules/type-fest": {
+			"version": "5.4.2",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.4.2.tgz",
+			"integrity": "sha512-FLEenlVYf7Zcd34ISMLo3ZzRE1gRjY1nMDTp+bQRBiPsaKyIW8K3Zr99ioHDUgA9OGuGGJPyYpNcffGmBhJfGg==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"dependencies": {
+				"tagged-tag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/read-pkg/node_modules/unicorn-magic": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+			"integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -14093,21 +14127,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/semantic-release/node_modules/normalize-package-data": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-8.0.0.tgz",
-			"integrity": "sha512-RWk+PI433eESQ7ounYxIp67CYuVsS1uYSonX3kA6ps/3LWfjVQa/ptEg6Y3T6uAMq1mWpX9PQ+qx+QaHpsc7gQ==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"hosted-git-info": "^9.0.0",
-				"semver": "^7.3.5",
-				"validate-npm-package-license": "^3.0.4"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
 		"node_modules/semantic-release/node_modules/npm-run-path": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
@@ -14138,37 +14157,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/semantic-release/node_modules/parse-json": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
-			"integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.26.2",
-				"index-to-position": "^1.1.0",
-				"type-fest": "^4.39.1"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/semantic-release/node_modules/parse-json/node_modules/type-fest": {
-			"version": "4.41.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
-			"engines": {
-				"node": ">=16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/semantic-release/node_modules/path-key": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
@@ -14177,44 +14165,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/semantic-release/node_modules/read-package-up": {
-			"version": "12.0.0",
-			"resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-12.0.0.tgz",
-			"integrity": "sha512-Q5hMVBYur/eQNWDdbF4/Wqqr9Bjvtrw2kjGxxBbKLbx8bVCL8gcArjTy8zDUuLGQicftpMuU0riQNcAsbtOVsw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"find-up-simple": "^1.0.1",
-				"read-pkg": "^10.0.0",
-				"type-fest": "^5.2.0"
-			},
-			"engines": {
-				"node": ">=20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/semantic-release/node_modules/read-pkg": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-10.0.0.tgz",
-			"integrity": "sha512-A70UlgfNdKI5NSvTTfHzLQj7NJRpJ4mT5tGafkllJ4wh71oYuGm/pzphHcmW4s35iox56KSK721AihodoXSc/A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/normalize-package-data": "^2.4.4",
-				"normalize-package-data": "^8.0.0",
-				"parse-json": "^8.3.0",
-				"type-fest": "^5.2.0",
-				"unicorn-magic": "^0.3.0"
-			},
-			"engines": {
-				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -14259,22 +14209,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/semantic-release/node_modules/type-fest": {
-			"version": "5.4.2",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.4.2.tgz",
-			"integrity": "sha512-FLEenlVYf7Zcd34ISMLo3ZzRE1gRjY1nMDTp+bQRBiPsaKyIW8K3Zr99ioHDUgA9OGuGGJPyYpNcffGmBhJfGg==",
-			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
-			"dependencies": {
-				"tagged-tag": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 		]
 	},
 	"dependencies": {
-		"@neovici/cosmoz-bottom-bar": "^7.0.0 || ^8.0.0 || ^9.0.0",
+		"@neovici/cosmoz-bottom-bar": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
 		"@neovici/cosmoz-i18next": "^3.0.0",
 		"@neovici/cosmoz-utils": "^6.0.0",
 		"@pionjs/pion": "^2.0.0",


### PR DESCRIPTION
## Summary

Update `@neovici/cosmoz-bottom-bar` dependency range to support v10.

## Changes

```diff
- "@neovici/cosmoz-bottom-bar": "^7.0.0 || ^8.0.0 || ^9.0.0",
+ "@neovici/cosmoz-bottom-bar": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
```

## Notes

This is a non-breaking change that expands the acceptable dependency range.

Relates to NEO-803