### PR TITLE
fix: support cosmoz-bottom-bar v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 		]
 	},
 	"dependencies": {
-		"@neovici/cosmoz-bottom-bar": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
+		"@neovici/cosmoz-bottom-bar": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
 		"@neovici/cosmoz-i18next": "^3.0.0",
 		"@neovici/cosmoz-utils": "^6.0.0",
 		"@pionjs/pion": "^2.0.0",


### PR DESCRIPTION
## Summary

- Add `^11.0.0` to the `cosmoz-bottom-bar` dependency range

## Context

`cosmoz-bottom-bar` v11 reverts from IntersectionObserver-based overflow to v8-style slot-based menu distribution (see [Neovici/cosmoz-bottom-bar#318](https://github.com/Neovici/cosmoz-bottom-bar/pull/318)). The API is compatible — no code changes needed in data-nav, just the version range update.