### PR TITLE
refactor: replace cosmoz-i18next with direct i18next

### DIFF
--- a/lib/use-incomplete-template.js
+++ b/lib/use-incomplete-template.js
@@ -4,7 +4,7 @@ import '@polymer/paper-icon-button';
 import '@polymer/paper-spinner/paper-spinner-lite';
 
 import '@neovici/cosmoz-bottom-bar';
-import { _ } from '@neovici/cosmoz-i18next';
+import { t } from 'i18next';
 
 const viewStyle = `
 	position: absolute;
@@ -35,7 +35,7 @@ export const useIncompleteTemplate = (index, length) => {
 				<div style="${scrollerContentStyle}">
 					<paper-spinner-lite active></paper-spinner-lite>
 					<div style="margin-left: 10px">
-						<h3><span>${_('Data is updating')}</span></h3>
+						<h3><span>${t('Data is updating')}</span></h3>
 					</div>
 				</div>
 				<cosmoz-bottom-bar active>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,18 +10,18 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@neovici/cosmoz-bottom-bar": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
-				"@neovici/cosmoz-i18next": "^3.0.0",
 				"@neovici/cosmoz-utils": "^6.0.0",
 				"@pionjs/pion": "^2.0.0",
 				"@polymer/paper-icon-button": "^3.0.0",
 				"@polymer/paper-spinner": "^3.0.0",
 				"@polymer/polymer": "^3.4.1",
+				"i18next": ">=23.0.0 <27.0.0",
 				"lit-html": "^2.0.0||^3.0.0"
 			},
 			"devDependencies": {
 				"@commitlint/cli": "^19.0.0",
 				"@commitlint/config-conventional": "^19.0.0",
-				"@neovici/cfg": "^2.8.0",
+				"@neovici/cfg": "^2.11.1",
 				"@open-wc/testing": "^4.0.0",
 				"@polymer/iron-icons": "^3.0.1",
 				"@polymer/paper-input": "^3.2.1",
@@ -1203,9 +1203,9 @@
 			}
 		},
 		"node_modules/@neovici/cfg": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/@neovici/cfg/-/cfg-2.8.1.tgz",
-			"integrity": "sha512-oAr8c6HMUDOJ0PK4UBT31nKEu0pfJsI1rxt7JY6ufVjEKrAH7XTTxxChhP/9NrTQwt7ucUNYbl30S+y4P548bw==",
+			"version": "2.11.1",
+			"resolved": "https://registry.npmjs.org/@neovici/cfg/-/cfg-2.11.1.tgz",
+			"integrity": "sha512-ZbmISYC3mS256hWg0MjZee7G4E7Y3Lmr4O5vsZJN1PcQ+IJVEPxKluaE5DiQD5CiNHxYpoMgVgumg3MNzd3eVw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -1267,16 +1267,6 @@
 				"@neovici/cosmoz-utils": "^6.8.1",
 				"@pionjs/pion": "^2.5.2",
 				"lit-html": "^3.1.2"
-			}
-		},
-		"node_modules/@neovici/cosmoz-i18next": {
-			"version": "3.5.2",
-			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-i18next/-/cosmoz-i18next-3.5.2.tgz",
-			"integrity": "sha512-T+kDuFJLhKGnhe3j9i28CofKTJHFU43XhNL9EKFXsqxpzn82+Dcc7SL6KtyeUnwIm3LaY30di/Qv1GQbGPnC1g==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@polymer/polymer": "^3.3.1",
-				"i18next": "^23.0.0"
 			}
 		},
 		"node_modules/@neovici/cosmoz-utils": {

--- a/package.json
+++ b/package.json
@@ -53,18 +53,18 @@
 	},
 	"dependencies": {
 		"@neovici/cosmoz-bottom-bar": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
-		"@neovici/cosmoz-i18next": "^3.0.0",
 		"@neovici/cosmoz-utils": "^6.0.0",
 		"@pionjs/pion": "^2.0.0",
 		"@polymer/paper-icon-button": "^3.0.0",
 		"@polymer/paper-spinner": "^3.0.0",
 		"@polymer/polymer": "^3.4.1",
+		"i18next": ">=23.0.0 <27.0.0",
 		"lit-html": "^2.0.0||^3.0.0"
 	},
 	"devDependencies": {
 		"@commitlint/cli": "^19.0.0",
 		"@commitlint/config-conventional": "^19.0.0",
-		"@neovici/cfg": "^2.8.0",
+		"@neovici/cfg": "^2.11.1",
 		"@open-wc/testing": "^4.0.0",
 		"@polymer/iron-icons": "^3.0.1",
 		"@polymer/paper-input": "^3.2.1",


### PR DESCRIPTION
## Summary
- replace `@neovici/cosmoz-i18next` usage in incomplete template rendering with direct `i18next` (`t('Data is updating')`)
- remove `@neovici/cosmoz-i18next` from dependencies and add direct `i18next` with range `>=23.0.0 <27.0.0`
- bump `@neovici/cfg` to `^2.11.1` and refresh lockfile

## Validation
- `npm run check:duplicates` ✅
- `npm test` ✅ (Chromium + Firefox: 50 passed, 0 failed, 19 skipped)
- `npm run lint` ✅ (no errors; existing warnings only)